### PR TITLE
27: Fix addressing when original request has no 'to' attribute

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -49,6 +49,7 @@ Monitoring Plugin Changelog
     <li>Requires Openfire 4.3.1</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/5'>Issue #5</a>] - MAM implementation should include urn:xmpp:mam:2</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/25'>Issue #25</a>] - When logging is disabled, queries should not go unanswered.</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/27'>Issue #27</a>] - Fix addressing when original request has no 'to' attribute.</li>
 </ul>
 
 <p><b>1.7.0</b> -- January 12, 2019</p>

--- a/src/java/com/reucon/openfire/plugin/archive/xep0313/IQQueryHandler0.java
+++ b/src/java/com/reucon/openfire/plugin/archive/xep0313/IQQueryHandler0.java
@@ -42,7 +42,7 @@ class IQQueryHandler0 extends IQQueryHandler {
 
     /**
      * Send final message back to client following query.
-     * @param JID to respond to
+     * @param from to respond to
      * @param queryRequest Received query request
      */
     private void sendFinalMessage(JID from, final QueryRequest queryRequest) {

--- a/src/java/com/reucon/openfire/plugin/archive/xep0313/IQQueryHandler1.java
+++ b/src/java/com/reucon/openfire/plugin/archive/xep0313/IQQueryHandler1.java
@@ -6,8 +6,6 @@ import org.slf4j.LoggerFactory;
 import org.xmpp.packet.IQ;
 import org.xmpp.packet.JID;
 
-import org.jivesoftware.openfire.XMPPServer;
-
 /**
  * XEP-0313 IQ Query Handler
  */
@@ -15,7 +13,6 @@ class IQQueryHandler1 extends IQQueryHandler {
 
     private static final Logger Log = LoggerFactory.getLogger(IQQueryHandler1.class);
     private static final String MODULE_NAME = "Message Archive Management Query Handler v1";
-    private static final String domain = XMPPServer.getInstance().getServerInfo().getXMPPDomain();
 
     IQQueryHandler1() {
         super(MODULE_NAME, "urn:xmpp:mam:1");
@@ -29,10 +26,10 @@ class IQQueryHandler1 extends IQQueryHandler {
     /**
      * Send result packet to client acknowledging query.
      * @param packet Received query packet
-     * @param JID to respond to
+     * @param from to respond to
      */
     private void sendAcknowledgementResult(IQ packet, JID from, QueryRequest queryRequest) {
-        if (packet.getTo() == null) packet.setTo(domain);
+        if (packet.getTo() == null) packet.setTo(from);
 
         IQ result = IQ.createResultIQ(packet);
         Element fin = result.setChildElement("fin", NAMESPACE);

--- a/src/java/com/reucon/openfire/plugin/archive/xep0313/IQQueryHandler2.java
+++ b/src/java/com/reucon/openfire/plugin/archive/xep0313/IQQueryHandler2.java
@@ -1,7 +1,6 @@
 package com.reucon.openfire.plugin.archive.xep0313;
 
 import org.dom4j.Element;
-import org.jivesoftware.openfire.XMPPServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmpp.packet.IQ;
@@ -14,7 +13,6 @@ class IQQueryHandler2 extends IQQueryHandler {
 
     private static final Logger Log = LoggerFactory.getLogger( IQQueryHandler2.class);
     private static final String MODULE_NAME = "Message Archive Management Query Handler v2";
-    private static final String domain = XMPPServer.getInstance().getServerInfo().getXMPPDomain();
 
     IQQueryHandler2() {
         super(MODULE_NAME, "urn:xmpp:mam:2");
@@ -28,10 +26,12 @@ class IQQueryHandler2 extends IQQueryHandler {
     /**
      * Send result packet to client acknowledging query.
      * @param packet Received query packet
-     * @param JID to respond to
+     * @param from to respond to
      */
     private void sendAcknowledgementResult(IQ packet, JID from, QueryRequest queryRequest) {
-        if (packet.getTo() == null) packet.setTo(domain);
+        if (packet.getTo() == null) {
+            packet.setTo(from);
+        }
 
         IQ result = IQ.createResultIQ(packet);
         Element fin = result.setChildElement("fin", NAMESPACE);


### PR DESCRIPTION
When there's no 'to' address in the request, the request is to be handled on behalf of
the requesting entity - not on behalf of the domain itself.

This should fix #27 .