### PR TITLE
fixes #58: Poor performance when adding messages to a large database.

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -46,6 +46,7 @@ Monitoring Plugin Changelog
     
 <p><b>1.8.2</b> -- (to be determined)</p>
 <ul>
+    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/58'>Issue #48</a>] - Fix for poor performance when adding messages to a large database.</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/46'>Issue #46</a>] - Specific messages do not show up in retrieved message history.</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/47'>Issue #47</a>] - Fix Syntax in SQL Statement for SQL Server in PaginatedMucMessageQuery</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/60'>Issue #53</a>] - Java11 ClassNotFoundException when deploying.</li>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,11 +6,11 @@
     <description>Monitors conversations and statistics of the server.</description>
     <author>IgniteRealtime // Jive Software</author>
     <version>${project.version}</version>
-    <date>09/25/2019</date>
+    <date>12/11/2019</date>
     <minServerVersion>4.4.0</minServerVersion>
     <minJavaVersion>1.8</minJavaVersion>
     <databaseKey>monitoring</databaseKey>
-    <databaseVersion>4</databaseVersion>
+    <databaseVersion>5</databaseVersion>
 
     <adminconsole>
         <tab id="tab-server">

--- a/src/database/monitoring_db2.sql
+++ b/src/database/monitoring_db2.sql
@@ -1,5 +1,5 @@
 
-INSERT INTO ofVersion (name, version) VALUES ('monitoring', 4);
+INSERT INTO ofVersion (name, version) VALUES ('monitoring', 5);
 
 CREATE TABLE ofConversation (
   conversationID        INTEGER      NOT NULL,

--- a/src/database/monitoring_hsqldb.sql
+++ b/src/database/monitoring_hsqldb.sql
@@ -1,5 +1,5 @@
 
-INSERT INTO ofVersion (name, version) VALUES ('monitoring', 4);
+INSERT INTO ofVersion (name, version) VALUES ('monitoring', 5);
 
 CREATE TABLE ofConversation (
   conversationID        BIGINT        NOT NULL,

--- a/src/database/monitoring_mysql.sql
+++ b/src/database/monitoring_mysql.sql
@@ -1,5 +1,5 @@
 
-INSERT INTO ofVersion (name, version) VALUES ('monitoring', 4);
+INSERT INTO ofVersion (name, version) VALUES ('monitoring', 5);
 
 CREATE TABLE ofConversation (
   conversationID        BIGINT        NOT NULL,

--- a/src/database/monitoring_oracle.sql
+++ b/src/database/monitoring_oracle.sql
@@ -1,5 +1,5 @@
 
-INSERT INTO ofVersion (name, version) VALUES ('monitoring', 4);
+INSERT INTO ofVersion (name, version) VALUES ('monitoring', 5);
 
 CREATE TABLE ofConversation (
   conversationID        INTEGER        NOT NULL,

--- a/src/database/monitoring_postgresql.sql
+++ b/src/database/monitoring_postgresql.sql
@@ -1,5 +1,5 @@
 
-INSERT INTO ofVersion (name, version) VALUES ('monitoring', 4);
+INSERT INTO ofVersion (name, version) VALUES ('monitoring', 5);
 
 CREATE TABLE ofConversation (
   conversationID        INTEGER       NOT NULL,

--- a/src/database/monitoring_sqlserver.sql
+++ b/src/database/monitoring_sqlserver.sql
@@ -1,5 +1,5 @@
 
-INSERT INTO ofVersion (name, version) VALUES ('monitoring', 4);
+INSERT INTO ofVersion (name, version) VALUES ('monitoring', 5);
 
 CREATE TABLE ofConversation (
   conversationID        BIGINT         NOT NULL,

--- a/src/database/upgrade/5/monitoring_db2.sql
+++ b/src/database/upgrade/5/monitoring_db2.sql
@@ -1,0 +1,4 @@
+INSERT INTO ofID (idType, id) VALUES (604, (SELECT coalesce(max(messageID), 0) + 1 FROM ofMessageArchive) );
+
+-- Update database version
+UPDATE ofVersion SET version = 5 WHERE name = 'monitoring';

--- a/src/database/upgrade/5/monitoring_hsqldb.sql
+++ b/src/database/upgrade/5/monitoring_hsqldb.sql
@@ -1,0 +1,4 @@
+INSERT INTO ofID (idType, id) VALUES (604, (SELECT coalesce(max(messageID), 0) + 1 FROM ofMessageArchive) );
+
+-- Update database version
+UPDATE ofVersion SET version = 5 WHERE name = 'monitoring';

--- a/src/database/upgrade/5/monitoring_mysql.sql
+++ b/src/database/upgrade/5/monitoring_mysql.sql
@@ -1,0 +1,4 @@
+INSERT INTO ofID (idType, id) VALUES (604, (SELECT coalesce(max(messageID), 0) + 1 FROM ofMessageArchive) );
+
+-- Update database version
+UPDATE ofVersion SET version = 5 WHERE name = 'monitoring';

--- a/src/database/upgrade/5/monitoring_oracle.sql
+++ b/src/database/upgrade/5/monitoring_oracle.sql
@@ -1,0 +1,6 @@
+INSERT INTO ofID (idType, id) VALUES (604, (SELECT coalesce(max(messageID), 0) + 1 FROM ofMessageArchive) );
+
+-- Update database version
+UPDATE ofVersion SET version = 5 WHERE name = 'monitoring';
+
+COMMIT;

--- a/src/database/upgrade/5/monitoring_postgresql.sql
+++ b/src/database/upgrade/5/monitoring_postgresql.sql
@@ -1,0 +1,4 @@
+INSERT INTO ofID (idType, id) VALUES (604, (SELECT coalesce(max(messageID), 0) + 1 FROM ofMessageArchive) );
+
+-- Update database version
+UPDATE ofVersion SET version = 5 WHERE name = 'monitoring';

--- a/src/database/upgrade/5/monitoring_sqlserver.sql
+++ b/src/database/upgrade/5/monitoring_sqlserver.sql
@@ -1,0 +1,4 @@
+INSERT INTO ofID (idType, id) VALUES (604, (SELECT coalesce(max(messageID), 0) + 1 FROM ofMessageArchive) );
+
+-- Update database version
+UPDATE ofVersion SET version = 5 WHERE name = 'monitoring';

--- a/src/java/org/jivesoftware/openfire/archive/ArchivedMessage.java
+++ b/src/java/org/jivesoftware/openfire/archive/ArchivedMessage.java
@@ -16,6 +16,9 @@
 
 package org.jivesoftware.openfire.archive;
 
+import org.jivesoftware.database.JiveID;
+import org.jivesoftware.database.SequenceManager;
+import org.jivesoftware.util.JiveConstants;
 import org.xmpp.packet.JID;
 
 import java.util.Date;
@@ -25,7 +28,13 @@ import java.util.Date;
  *
  * @author Matt Tucker
  */
+@JiveID(604)
 public class ArchivedMessage {
+
+    static {
+        // Instantiate a sequence manager to ensure that a block size larger than the default value of '1' is used.
+        new SequenceManager(604, 50);
+    }
 
     private long conversationID;
     private JID fromJID;

--- a/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
+++ b/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
@@ -21,6 +21,7 @@ import org.dom4j.DocumentException;
 import org.dom4j.DocumentHelper;
 import org.dom4j.Element;
 import org.jivesoftware.database.DbConnectionManager;
+import org.jivesoftware.database.SequenceManager;
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.XMPPServerInfo;
 import org.jivesoftware.openfire.archive.cluster.GetConversationCountTask;
@@ -1162,14 +1163,14 @@ public class ConversationManager implements Startable, ComponentEventListener{
 
             try
             {
-                int msgCount = getArchivedMessageCount();
-
                 con = DbConnectionManager.getConnection();
                 pstmt = con.prepareStatement(INSERT_MESSAGE);
 
                 for ( final ArchivedMessage work : workQueue )
                 {
-                    pstmt.setInt(1, ++msgCount);
+                    long id = SequenceManager.nextID(work);
+
+                    pstmt.setLong(1, id);
                     pstmt.setLong(2, work.getConversationID());
                     pstmt.setString(3, work.getFromJID().toBareJID());
                     pstmt.setString(4, work.getFromJID().getResource());


### PR DESCRIPTION
This commit replaces the mechanism to determine the next (unique) messageID value for rows in the ofMessageArchive table.

Instead of using count(*) to determine the next value, a sequence is used (as provided by Openfire's SequenceManager).

A database update script has been included that automatically initializes the sequence to the correct value, for databases that already have content.