### PR TITLE
fix #76

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -43,9 +43,10 @@
 <h1>
 Monitoring Plugin Changelog
 </h1>
-    
+
 <p><b>1.8.2</b> -- (to be determined)</p>
 <ul>
+    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/76'>Issue #76</a>] - Monitoring plugin does not retrieve last page of chat history when <before> is empty.</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/58'>Issue #48</a>] - Fix for poor performance when adding messages to a large database.</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/46'>Issue #46</a>] - Specific messages do not show up in retrieved message history.</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/47'>Issue #47</a>] - Fix Syntax in SQL Statement for SQL Server in PaginatedMucMessageQuery</li>

--- a/src/java/com/reucon/openfire/plugin/archive/impl/JdbcPersistenceManager.java
+++ b/src/java/com/reucon/openfire/plugin/archive/impl/JdbcPersistenceManager.java
@@ -61,16 +61,16 @@ public class JdbcPersistenceManager implements PersistenceManager {
         public static final String SELECT_CONVERSATIONS_GROUP_BY = " GROUP BY ofConversation.conversationID, ofConversation.room, ofConversation.isExternal, ofConversation.lastActivity, ofConversation.messageCount, ofConversation.startDate, ofConParticipant.bareJID, ofConParticipant.jidResource, ofConParticipant.nickname, ofConParticipant.bareJID, ofMessageArchive.toJID";
 
     // public static final String SELECT_CONVERSATIONS = "SELECT DISTINCT " + "ofConversation.conversationID, " + "ofConversation.room, "
-    // 		+ "ofConversation.isExternal, " + "ofConversation.startDate, " + "ofConversation.lastActivity, " + "ofConversation.messageCount, "
-    // 		+ "ofConParticipant.joinedDate, " + "ofConParticipant.leftDate, " + "ofConParticipant.bareJID, " + "ofConParticipant.jidResource, "
-    // 		+ "ofConParticipant.nickname, "
-    // 		+ "ofConParticipant.bareJID as fromJID, "
-        // 		+ "ofMessageArchive.toJID "
-    // 		+ "FROM ofConversation "
-    // 		+ "INNER JOIN ofConParticipant ON ofConversation.conversationID = ofConParticipant.conversationID "
-    // 		+ "INNER JOIN (SELECT conversationID, toJID FROM ofMessageArchive "
-    // 		+ "union all "
-    // 		+ "SELECT conversationID, fromJID as toJID FROM ofMessageArchive) ofMessageArchive ON ofConParticipant.conversationID = ofMessageArchive.conversationID";
+    //      + "ofConversation.isExternal, " + "ofConversation.startDate, " + "ofConversation.lastActivity, " + "ofConversation.messageCount, "
+    //      + "ofConParticipant.joinedDate, " + "ofConParticipant.leftDate, " + "ofConParticipant.bareJID, " + "ofConParticipant.jidResource, "
+    //      + "ofConParticipant.nickname, "
+    //      + "ofConParticipant.bareJID as fromJID, "
+        //      + "ofMessageArchive.toJID "
+    //      + "FROM ofConversation "
+    //      + "INNER JOIN ofConParticipant ON ofConversation.conversationID = ofConParticipant.conversationID "
+    //      + "INNER JOIN (SELECT conversationID, toJID FROM ofMessageArchive "
+    //      + "union all "
+    //      + "SELECT conversationID, fromJID as toJID FROM ofMessageArchive) ofMessageArchive ON ofConParticipant.conversationID = ofMessageArchive.conversationID";
 
     // public static final String SELECT_CONVERSATIONS =
     // "SELECT c.conversationId,c.startTime,c.endTime,c.ownerJid,c.ownerResource,c.withJid,c.withResource,"
@@ -518,6 +518,16 @@ public class JdbcPersistenceManager implements PersistenceManager {
                 if (firstIndex < 0) {
                     firstIndex = 0;
                 }
+            }
+            else if (xmppResultSet.isPagingBackwards()){
+                int messagesCount = countMessages(startDate, endDate, owner, with, whereSB.toString());
+                firstIndex = messagesCount;
+                firstIndex -= max;
+
+                if (max > messagesCount) max = messagesCount;
+                if (firstIndex < 0) firstIndex = 0;
+
+                reverse = true;
             }
             firstIndex = firstIndex != null ? firstIndex : 0;
 

--- a/src/java/com/reucon/openfire/plugin/archive/impl/JdbcPersistenceManager.java
+++ b/src/java/com/reucon/openfire/plugin/archive/impl/JdbcPersistenceManager.java
@@ -520,7 +520,7 @@ public class JdbcPersistenceManager implements PersistenceManager {
                 }
             }
             else if (xmppResultSet.isPagingBackwards()){
-                int messagesCount = countMessages(startDate, endDate, owner, with, whereSB.toString());
+                int messagesCount = countMessages(startDate, endDate, ownerJid, withJid, whereSB.toString());
                 firstIndex = messagesCount;
                 firstIndex -= max;
 


### PR DESCRIPTION
Monitoring plugin does not retrieve last page of chat history when <before> is empty
This fix adds handling of xmppResultSet.isPagingBackwards() in findMessages()