### PR TITLE
Fix remove features on unload

### DIFF
--- a/src/java/org/jivesoftware/openfire/plugin/MonitoringPlugin.java
+++ b/src/java/org/jivesoftware/openfire/plugin/MonitoringPlugin.java
@@ -219,6 +219,12 @@ public class MonitoringPlugin implements Plugin {
             picoContainer.dispose();
             picoContainer = null;
         }
+        
+        xep0136Support.stop();
+        xep0313Support.stop();
+        xep0313Support1.stop();
+        xep0313Support2.stop();
+        
         instance = null;
     }
 


### PR DESCRIPTION
On pluginunload the features:
```
<feature var="urn:xmpp:mam:0" />
<feature var="urn:xmpp:mam:1" />
<feature var="urn:xmpp:mam:2" />
```
where not removed from disco list, so on plugin refresh (admin console) there were added again

this fix fixed this behaviour