### PR TITLE
fixes #101: Do not assume XEP-0359 values to be UUIDs

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -44,6 +44,12 @@
 Monitoring Plugin Changelog
 </h1>
 
+<p><b>2.0.2</b> -- (tbd)</p>
+<ul>
+    <li>Requires Openfire 4.5.2</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/101'>Issue #101</a>] - Stable and Unique stanza identifiers need not be in the UUID format.</li>
+</ul>
+
 <p><b>2.0.1</b> -- May 11, 2020</p>
 <ul>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/91'>Issue #91</a>] - Exception when search text contains special characters</li>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,8 +6,8 @@
     <description>Monitors conversations and statistics of the server.</description>
     <author>IgniteRealtime // Jive Software</author>
     <version>${project.version}</version>
-    <date>05/11/2020</date>
-    <minServerVersion>4.4.0</minServerVersion>
+    <date>05/18/2020</date>
+    <minServerVersion>4.5.2</minServerVersion>
     <minJavaVersion>1.8</minJavaVersion>
     <databaseKey>monitoring</databaseKey>
     <databaseVersion>6</databaseVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.4.0-beta</version>
+        <version>4.5.2</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>monitoring</artifactId>

--- a/src/java/com/reucon/openfire/plugin/archive/ArchiveFactory.java
+++ b/src/java/com/reucon/openfire/plugin/archive/ArchiveFactory.java
@@ -1,7 +1,6 @@
 package com.reucon.openfire.plugin.archive;
 
 import java.util.Date;
-import java.util.UUID;
 
 import org.jivesoftware.openfire.session.Session;
 import org.jivesoftware.openfire.stanzaid.StanzaIDUtil;
@@ -20,7 +19,7 @@ public class ArchiveFactory {
 
     public static ArchivedMessage createArchivedMessage(Session session,
             Message message, ArchivedMessage.Direction direction, JID owner, JID with) {
-        final UUID sid = StanzaIDUtil.parseUniqueAndStableStanzaID( message, owner.toBareJID() );
+        final String sid = StanzaIDUtil.findFirstUniqueAndStableStanzaID( message, owner.toBareJID() );
         final ArchivedMessage archivedMessage;
 
         archivedMessage = new ArchivedMessage(new Date(), direction, message.getType().toString(), with, sid);

--- a/src/java/com/reucon/openfire/plugin/archive/impl/JdbcPersistenceManager.java
+++ b/src/java/com/reucon/openfire/plugin/archive/impl/JdbcPersistenceManager.java
@@ -594,12 +594,12 @@ public class JdbcPersistenceManager implements PersistenceManager {
                 final long id = rs.getLong( "messageID" );
                 final Date time = millisToDate(rs.getLong("sentDate"));
 
-                UUID sid = null;
+                String sid = null;
                 if ( stanza != null && !stanza.isEmpty() ) {
                     try {
                         final Document doc = DocumentHelper.parseText( stanza );
                         final Message message = new Message( doc.getRootElement() );
-                        sid = StanzaIDUtil.parseUniqueAndStableStanzaID( message, owner.toBareJID() );
+                        sid = StanzaIDUtil.findFirstUniqueAndStableStanzaID( message, owner.toBareJID() );
                     } catch ( Exception e ) {
                         Log.warn( "An exception occurred while parsing message with ID {}", id, e );
                         sid = null;
@@ -990,12 +990,12 @@ public class JdbcPersistenceManager implements PersistenceManager {
             with = new JID(rs.getString("fromJID"));
         }
 
-        UUID sid = null;
+        String sid = null;
         if ( stanza != null && !stanza.isEmpty() ) {
             try {
                 final Document doc = DocumentHelper.parseText( stanza );
                 final Message m = new Message( doc.getRootElement() );
-                sid = StanzaIDUtil.parseUniqueAndStableStanzaID( m, new JID( bareJid ).toBareJID() );
+                sid = StanzaIDUtil.findFirstUniqueAndStableStanzaID( m, new JID( bareJid ).toBareJID() );
             } catch ( Exception e ) {
                 Log.warn( "An exception occurred while parsing message with ID {}", id, e );
                 sid = null;

--- a/src/java/com/reucon/openfire/plugin/archive/model/ArchivedMessage.java
+++ b/src/java/com/reucon/openfire/plugin/archive/model/ArchivedMessage.java
@@ -32,9 +32,9 @@ public class ArchivedMessage {
     private Conversation conversation;
     private JID with;
     private String stanza;
-    private UUID stableId;
+    private String stableId;
 
-    public ArchivedMessage( Date time, Direction direction, String type, JID with, UUID stableId) {
+    public ArchivedMessage( Date time, Direction direction, String type, JID with, String stableId ) {
         this.time = time;
         this.direction = direction;
         this.type = type;
@@ -108,12 +108,17 @@ public class ArchivedMessage {
         return with;
     }
 
-    public UUID getStableId()
+    public String getStableId()
     {
         return stableId;
     }
 
     public void setStableId( final UUID stableId )
+    {
+        this.stableId = stableId.toString();
+    }
+
+    public void setStableId( final String stableId )
     {
         this.stableId = stableId;
     }


### PR DESCRIPTION
Although the XEP specifies that XEP-0359 identifiers SHOULD be UUIDs, they need not be. At least one third party implementation (converse.js) is known to not use UUIDs.

This change replaces the UUID format with a regular string. This will make detection of 'XEP-0359 usage' less precise. In the old code, the existence of a UUID value in the stanza text was used. To prevent any stanza to match common identifiers, an additional check is added that requires the stanza to contain the XEP-0359 namespace. Far from ideal, but until we properly spread things over queryable database columns...