### PR TITLE
Fix issue #103 Log flooded with invalid sample time for statistics

### DIFF
--- a/src/java/org/jivesoftware/openfire/reporting/stats/StatsEngine.java
+++ b/src/java/org/jivesoftware/openfire/reporting/stats/StatsEngine.java
@@ -367,6 +367,7 @@ public class StatsEngine implements Startable {
                     if(newTime <= db.getLastArchiveUpdateTime()) {
                         Log.warn("Sample time of " + newTime +  " for statistic " + key + " is " +
                                 "invalid.");
+                        continue;
                     }
                     Sample sample = db.createSample(newTime);
 


### PR DESCRIPTION
Added a continue statement after the Log.warn statement. This will skip the sample creation and update for the current statistic. It could still create a bunch of warn level log entries, but not the error level messages with stacktrace produced by the RrdException thrown by sample.update().