### PR TITLE
GetConversations on a Cluster might return unexpectedly null.

### DIFF
--- a/src/java/org/jivesoftware/openfire/archive/Conversation.java
+++ b/src/java/org/jivesoftware/openfire/archive/Conversation.java
@@ -606,6 +606,7 @@ public class Conversation implements Externalizable {
     }
 
     public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+      Log.debug("readExternal");
         MonitoringPlugin plugin = (MonitoringPlugin) XMPPServer.getInstance().getPluginManager().getPlugin(MonitoringConstants.NAME);
         conversationManager = (ConversationManager) plugin.getModule(ConversationManager.class);
 


### PR DESCRIPTION
In an clustered environment, the active conversations are not correctly retrieved on the Junior members. These modification are made to minimise the impact of this.