### PR TITLE
fixes #118: Drop min required Openfire version back to 4.4.0

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -51,6 +51,7 @@ Monitoring Plugin Changelog
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/103'>Issue #103</a>] - Log flooded with invalid sample time for statistics</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/108'>Issue #108</a>] - Return 'feature-not-implemented' when request for 'out of order' MAM result page.</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/110'>Issue #110</a>] - Optimize database: when there are no results, don't bother to query for a subset.</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/118'>Issue #118</a>] - Drop Openfire requirement to 4.4.0.</li>
 </ul>
 
 <p><b>2.0.1</b> -- May 11, 2020</p>

--- a/plugin.xml
+++ b/plugin.xml
@@ -7,7 +7,7 @@
     <author>IgniteRealtime // Jive Software</author>
     <version>${project.version}</version>
     <date>05/18/2020</date>
-    <minServerVersion>4.5.2</minServerVersion>
+    <minServerVersion>4.4.0</minServerVersion>
     <minJavaVersion>1.8</minJavaVersion>
     <databaseKey>monitoring</databaseKey>
     <databaseVersion>6</databaseVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.5.2-SNAPSHOT</version>
+        <version>4.4.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>monitoring</artifactId>

--- a/src/java/com/reucon/openfire/plugin/archive/ArchiveFactory.java
+++ b/src/java/com/reucon/openfire/plugin/archive/ArchiveFactory.java
@@ -3,7 +3,7 @@ package com.reucon.openfire.plugin.archive;
 import java.util.Date;
 
 import org.jivesoftware.openfire.session.Session;
-import org.jivesoftware.openfire.stanzaid.StanzaIDUtil;
+import com.reucon.openfire.plugin.archive.util.StanzaIDUtil;
 import org.xmpp.packet.JID;
 import org.xmpp.packet.Message;
 

--- a/src/java/com/reucon/openfire/plugin/archive/impl/JdbcPersistenceManager.java
+++ b/src/java/com/reucon/openfire/plugin/archive/impl/JdbcPersistenceManager.java
@@ -14,7 +14,7 @@ import org.dom4j.Element;
 import org.jivesoftware.database.DbConnectionManager;
 import org.jivesoftware.openfire.archive.ConversationManager;
 import org.jivesoftware.openfire.muc.MUCRoom;
-import org.jivesoftware.openfire.stanzaid.StanzaIDUtil;
+import com.reucon.openfire.plugin.archive.util.StanzaIDUtil;
 import org.jivesoftware.util.JiveConstants;
 import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.NotFoundException;

--- a/src/java/com/reucon/openfire/plugin/archive/impl/MucMamPersistenceManager.java
+++ b/src/java/com/reucon/openfire/plugin/archive/impl/MucMamPersistenceManager.java
@@ -12,7 +12,7 @@ import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.muc.MUCRoom;
 import org.jivesoftware.openfire.muc.MultiUserChatManager;
 import org.jivesoftware.openfire.muc.MultiUserChatService;
-import org.jivesoftware.openfire.stanzaid.StanzaIDUtil;
+import com.reucon.openfire.plugin.archive.util.StanzaIDUtil;
 import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.NotFoundException;
 import org.slf4j.Logger;

--- a/src/java/com/reucon/openfire/plugin/archive/impl/PaginatedMessageDatabaseQuery.java
+++ b/src/java/com/reucon/openfire/plugin/archive/impl/PaginatedMessageDatabaseQuery.java
@@ -18,7 +18,7 @@ import com.reucon.openfire.plugin.archive.model.ArchivedMessage;
 import org.dom4j.Document;
 import org.dom4j.DocumentHelper;
 import org.jivesoftware.database.DbConnectionManager;
-import org.jivesoftware.openfire.stanzaid.StanzaIDUtil;
+import com.reucon.openfire.plugin.archive.util.StanzaIDUtil;
 import org.jivesoftware.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/java/com/reucon/openfire/plugin/archive/util/StanzaIDUtil.java
+++ b/src/java/com/reucon/openfire/plugin/archive/util/StanzaIDUtil.java
@@ -1,0 +1,67 @@
+package com.reucon.openfire.plugin.archive.util;
+
+import org.dom4j.Element;
+import org.dom4j.QName;
+import org.jivesoftware.util.JiveGlobals;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xmpp.packet.*;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.UUID;
+
+/*
+ * This is a partial copy of the implementation provided in Openfire 4.5.2 by
+ * {@link org.jivesoftware.openfire.stanzaid.StanzaIDUtil}. The implementation is copied into this plugin to retain
+ * compatibility with older versions of Openfire. This class should be removed when this plugin starts requiring
+ * Openfire 4.5.2 or later.
+ *
+ * @see <a href="https://github.com/igniterealtime/openfire-monitoring-plugin/issues/118">Issue #118</a>
+ * @author Guus der Kinderen, guus.der.kinderen@gmail.com
+ */
+// FIXME Remove/Replace with org.jivesoftware.openfire.stanzaid.StanzaIDUtil when minimum server requirement becomes 4.5.2 or later.
+public class StanzaIDUtil
+{
+    /**
+     * Returns the first stable and unique stanza-id value from the packet, that is defined
+     * for a particular 'by' value.
+     *
+     * This method does not evaluate 'origin-id' elements in the packet.
+     *
+     * @param packet The stanza (cannot be null).
+     * @param by The 'by' value for which to return the ID (cannot be null or an empty string).
+     * @return The unique and stable ID, or null if no such ID is found.
+     */
+    public static String findFirstUniqueAndStableStanzaID( final Packet packet, final String by )
+    {
+        if ( packet == null )
+        {
+            throw new IllegalArgumentException( "Argument 'packet' cannot be null." );
+        }
+        if ( by == null || by.isEmpty() )
+        {
+            throw new IllegalArgumentException( "Argument 'by' cannot be null or an empty string." );
+        }
+
+        final List<Element> sids = packet.getElement().elements( QName.get( "stanza-id", "urn:xmpp:sid:0" ) );
+        if ( sids == null )
+        {
+            return null;
+        }
+
+        for ( final Element sid : sids )
+        {
+            if ( by.equals( sid.attributeValue( "by" ) ) )
+            {
+                final String result = sid.attributeValue( "id" );
+                if ( result != null && !result.isEmpty() )
+                {
+                    return result;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
+++ b/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
@@ -34,7 +34,7 @@ import org.jivesoftware.openfire.component.InternalComponentManager;
 import org.jivesoftware.openfire.muc.MultiUserChatService;
 import org.jivesoftware.openfire.plugin.MonitoringPlugin;
 import org.jivesoftware.openfire.reporting.util.TaskEngine;
-import org.jivesoftware.openfire.stanzaid.StanzaIDUtil;
+import com.reucon.openfire.plugin.archive.util.StanzaIDUtil;
 import org.jivesoftware.openfire.stats.Statistic;
 import org.jivesoftware.openfire.stats.StatisticsManager;
 import org.jivesoftware.util.*;


### PR DESCRIPTION
By copying one method from Openfire 4.5.2, we can drop the required version back to 4.4.0.

When we eventually raise the minimum Openfire requirement, this PR should be undone.