### PR TITLE
fixes #155: Use plugin-specific ArchiveManager

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -46,6 +46,7 @@ Monitoring Plugin Changelog
 
 <p><b>2.2.1</b> -- (tbd)</p>
 <ul>
+    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/155'>Issue #155</a>] - Stop requiring a restart of Openfire after reloading the monitoring plugin</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/157'>Issue #157</a>] - Poor MAM performance with large archives</li>
 </ul>
 

--- a/src/java/com/reucon/openfire/plugin/archive/xep0313/IQQueryHandler.java
+++ b/src/java/com/reucon/openfire/plugin/archive/xep0313/IQQueryHandler.java
@@ -32,8 +32,7 @@ import java.text.ParseException;
 import java.time.*;
 import java.util.*;
 import java.util.LinkedList;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.*;
 import java.util.stream.Collectors;
 
 /**
@@ -68,7 +67,9 @@ abstract class IQQueryHandler extends AbstractIQHandler implements
     public void initialize( XMPPServer server )
     {
         super.initialize( server );
-        executorService = Executors.newCachedThreadPool( new NamedThreadFactory( "message-archive-handler-", null, null, null ) );
+        final ThreadFactory threadFactory = new NamedThreadFactory( "message-archive-handler-", null, null, null );
+        executorService = new ThreadPoolExecutor(0, Integer.MAX_VALUE,0, TimeUnit.SECONDS, new SynchronousQueue<>(), threadFactory);
+        //executorService = Executors.newCachedThreadPool( new NamedThreadFactory( "message-archive-handler-", null, null, null ) );
         router = server.getPacketRouter();
     }
 

--- a/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
+++ b/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
@@ -188,11 +188,12 @@ public class ConversationManager implements Startable, ComponentEventListener{
             executorField.setAccessible(true);
             ((ExecutorService) executorField.get(archiveManager)).shutdown();
             executorField.set(archiveManager,
-                new ForceClosingThreadPoolExecutor(
-                    Executors.newCachedThreadPool(
-                        new NamedThreadFactory("archive-monitoring-service-worker-", null, null, null)
-                    )
-                )
+                new ThreadPoolExecutor(0, Integer.MAX_VALUE,0, TimeUnit.SECONDS, new SynchronousQueue<>(), new NamedThreadFactory("archive-monitoring-service-worker-", null, null, null) )
+//                new ForceClosingThreadPoolExecutor(
+//                    Executors.newCachedThreadPool(
+//                        new NamedThreadFactory("archive-monitoring-service-worker-", null, null, null)
+//                    )
+//                )
             );
             executorField.setAccessible(false);
         } catch (Exception e) {

--- a/src/java/org/jivesoftware/openfire/plugin/ForceClosingThreadPoolExecutor.java
+++ b/src/java/org/jivesoftware/openfire/plugin/ForceClosingThreadPoolExecutor.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2021 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire.plugin;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.*;
+
+/**
+ * A delegating ExecutorService that attempts to coerce any threads that were used by the delegate to stop to exist,
+ * after the instance is shut down.
+ *
+ * The purpose of this implementation is to facilitate that the classloader that has loaded the instance becomes
+ * eligible for garbage collection fast.
+ *
+ * @author Guus der Kinderen, guus.der.kinderen@gmail.com
+ * @see <a href="https://github.com/igniterealtime/openfire-monitoring-plugin/issues/155">Issue #155</a>
+ */
+public class ForceClosingThreadPoolExecutor implements ExecutorService {
+
+    final ExecutorService delegate;
+
+    public ForceClosingThreadPoolExecutor(@Nonnull final ExecutorService delegate) {
+        this.delegate = delegate;
+    }
+
+    protected void killThreads()
+    {
+        if (delegate instanceof ThreadPoolExecutor) {
+            // Issue #155: References to classes (used during execution of Runnable instances) exist for as long as the
+            // duration of the keepAliveTime. It is assumed that even after termination, (cached) threads exist, that keep
+            // these references alive. This in turn prevents garbage collection, which in turn leads to classloading
+            // problems when a new instance of the plugin that this code is part if is being loaded. The next two lines try
+            // to coerce threads from being removed, thus preventing the issue.
+            ((ThreadPoolExecutor) delegate).allowCoreThreadTimeOut(true);
+            ((ThreadPoolExecutor) delegate).setKeepAliveTime(1, TimeUnit.NANOSECONDS);
+        }
+    }
+
+    public void shutdown() {
+        delegate.shutdown();
+    }
+
+    public List<Runnable> shutdownNow() {
+        return delegate.shutdownNow();
+    }
+
+    public boolean isShutdown() {
+        return delegate.isShutdown();
+    }
+
+    public boolean isTerminated() {
+        return delegate.isTerminated();
+    }
+
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return delegate.awaitTermination(timeout, unit);
+    }
+
+    public <T> Future<T> submit(Callable<T> task) {
+        return delegate.submit(task);
+    }
+
+    public <T> Future<T> submit(Runnable task, T result) {
+        return delegate.submit(task, result);
+    }
+
+    public Future<?> submit(Runnable task) {
+        return delegate.submit(task);
+    }
+
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        return delegate.invokeAll(tasks);
+    }
+
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
+        return delegate.invokeAll(tasks, timeout, unit);
+    }
+
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+        return delegate.invokeAny(tasks);
+    }
+
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        return delegate.invokeAny(tasks, timeout, unit);
+    }
+
+    public void execute(Runnable command) {
+        delegate.execute(command);
+    }
+}

--- a/src/java/org/jivesoftware/openfire/reporting/util/TaskEngine.java
+++ b/src/java/org/jivesoftware/openfire/reporting/util/TaskEngine.java
@@ -16,6 +16,7 @@
 
 package org.jivesoftware.openfire.reporting.util;
 
+import org.jivesoftware.openfire.plugin.ForceClosingThreadPoolExecutor;
 import org.jivesoftware.util.NamedThreadFactory;
 import org.picocontainer.Disposable;
 import org.slf4j.Logger;
@@ -59,7 +60,7 @@ public class TaskEngine implements Disposable {
     private TaskEngine() {
         timer = new Timer("timer-monitoring", true);
         final ThreadFactory threadFactory = new NamedThreadFactory( "pool-monitoring", true, Thread.NORM_PRIORITY, Thread.currentThread().getThreadGroup(), 0L );
-        executor = Executors.newCachedThreadPool( threadFactory );
+        executor = new ForceClosingThreadPoolExecutor( Executors.newCachedThreadPool(threadFactory) );
     }
 
     /**

--- a/src/java/org/jivesoftware/openfire/reporting/util/TaskEngine.java
+++ b/src/java/org/jivesoftware/openfire/reporting/util/TaskEngine.java
@@ -60,7 +60,8 @@ public class TaskEngine implements Disposable {
     private TaskEngine() {
         timer = new Timer("timer-monitoring", true);
         final ThreadFactory threadFactory = new NamedThreadFactory( "pool-monitoring", true, Thread.NORM_PRIORITY, Thread.currentThread().getThreadGroup(), 0L );
-        executor = new ForceClosingThreadPoolExecutor( Executors.newCachedThreadPool(threadFactory) );
+//        executor = new ForceClosingThreadPoolExecutor( Executors.newCachedThreadPool(threadFactory) );
+        executor = new ThreadPoolExecutor(0, Integer.MAX_VALUE,0, TimeUnit.SECONDS, new SynchronousQueue<>(), threadFactory);
     }
 
     /**


### PR DESCRIPTION
By using an ArchiveManager that is started and stopped with the plugin, we're preventing Openfire's instance to retain references to the tasks that it executes (which leads to classcastexceptions).