### PR TITLE
fixes #157: Switch unnecessary LIKE on toJid for an exact match

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -44,6 +44,11 @@
 Monitoring Plugin Changelog
 </h1>
 
+<p><b>2.2.1</b> -- (tbd)</p>
+<ul>
+    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/157'>Issue #157</a>] - Poor MAM performance with large archives</li>
+</ul>
+
 <p><b>2.2.0</b> -- January 6, 2021</p>
 <ul>
     <li>[<a href='https://issues.igniterealtime.org/browse/OF-2157'>OF-2157</a>] - SequenceManager generated IDs are unreliable whilst clustering.</li>

--- a/src/java/com/reucon/openfire/plugin/archive/impl/MucMamPersistenceManager.java
+++ b/src/java/com/reucon/openfire/plugin/archive/impl/MucMamPersistenceManager.java
@@ -234,7 +234,7 @@ public class MucMamPersistenceManager implements PersistenceManager {
                 pstmt.setLong( 1, messageId );
                 pstmt.setLong( 2, room.getID());
             } else {
-                pstmt = connection.prepareStatement("SELECT fromJid, toJidResource, sentdate, fromJidResource, body, stanza, messageId FROM ofMessageArchive WHERE messageID = ? and toJid LIKE ?");
+                pstmt = connection.prepareStatement("SELECT fromJid, toJidResource, sentdate, fromJidResource, body, stanza, messageId FROM ofMessageArchive WHERE messageID = ? and toJid=?");
                 pstmt.setLong( 1, messageId );
                 pstmt.setString( 2, room.getJID().toBareJID());
             }
@@ -329,7 +329,7 @@ public class MucMamPersistenceManager implements PersistenceManager {
                 pstmt = connection.prepareStatement( "SELECT messageId, stanza FROM ofMucConversationLog WHERE messageId IS NOT NULL AND roomID=? AND stanza LIKE ? AND stanza LIKE ?" );
                 pstmt.setLong( 1, room.getID() );
             } else {
-                pstmt = connection.prepareStatement("SELECT messageId, stanza FROM ofMessageArchive WHERE messageID IS NOT NULL AND toJid LIKE ? AND stanza LIKE ? AND stanza LIKE ?");
+                pstmt = connection.prepareStatement("SELECT messageId, stanza FROM ofMessageArchive WHERE messageID IS NOT NULL AND toJid=? AND stanza LIKE ? AND stanza LIKE ?");
                 pstmt.setString( 1, room.getJID().toBareJID());
             }
 
@@ -387,7 +387,7 @@ public class MucMamPersistenceManager implements PersistenceManager {
                 pstmt = connection.prepareStatement("SELECT MIN(logTime) FROM ofMucConversationLog WHERE roomid = ?");
                 pstmt.setLong(1, room.getID());
             } else {
-                pstmt = connection.prepareStatement("SELECT MIN(sentDate) FROM ofMessageArchive WHERE toJid LIKE ?");
+                pstmt = connection.prepareStatement("SELECT MIN(sentDate) FROM ofMessageArchive WHERE toJid=?");
                 pstmt.setString(1, room.getJID().toBareJID());
             }
             rs = pstmt.executeQuery();
@@ -414,7 +414,7 @@ public class MucMamPersistenceManager implements PersistenceManager {
                 pstmt = connection.prepareStatement("SELECT MAX(logTime) FROM ofMucConversationLog WHERE roomid = ?");
                 pstmt.setLong(1, room.getID());
             } else {
-                pstmt = connection.prepareStatement("SELECT MAX(sentDate) FROM ofMessageArchive WHERE toJid LIKE ?");
+                pstmt = connection.prepareStatement("SELECT MAX(sentDate) FROM ofMessageArchive WHERE toJid=?");
                 pstmt.setString(1, room.getJID().toBareJID());
             }
             rs = pstmt.executeQuery();


### PR DESCRIPTION
toJid for MUC will always be the exact bare JID. Anything that doesn't match we don't want, and DMs are accounted for by the toJidResource field.