### PR TITLE
fixes #167: Deal with empty stanzas in db when processing MAM queries

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -47,6 +47,7 @@ Monitoring Plugin Changelog
 <p><b>2.2.1</b> -- (tbd)</p>
 <ul>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/157'>Issue #157</a>] - Poor MAM performance with large archives</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/167'>Issue #167</a>] - Deal with empty stanzas in db when processing MAM queries</li>
 </ul>
 
 <p><b>2.2.0</b> -- January 6, 2021</p>

--- a/src/java/com/reucon/openfire/plugin/archive/model/ArchivedMessage.java
+++ b/src/java/com/reucon/openfire/plugin/archive/model/ArchivedMessage.java
@@ -83,6 +83,7 @@ public class ArchivedMessage {
                 final Document doc = DocumentHelper.parseText( stanza );
                 stanzaResult = new Message( doc.getRootElement() );
             } catch (DocumentException de) {
+                Log.debug("Unable to parse (non-empty) stanza (id: {})", id, de);
                 stanzaResult = null;
             }
             this.stanza = stanzaResult;

--- a/src/java/com/reucon/openfire/plugin/archive/model/ArchivedMessage.java
+++ b/src/java/com/reucon/openfire/plugin/archive/model/ArchivedMessage.java
@@ -77,9 +77,15 @@ public class ArchivedMessage {
         this.with = with;
         this.body = body;
 
-        if ( stanza != null) {
-            final Document doc = DocumentHelper.parseText( stanza );
-            this.stanza = new Message( doc.getRootElement() );
+        if ( stanza != null && stanza.length() > 0 ) {
+            Message stanzaResult;
+            try {
+                final Document doc = DocumentHelper.parseText( stanza );
+                stanzaResult = new Message( doc.getRootElement() );
+            } catch (DocumentException de) {
+                stanzaResult = null;
+            }
+            this.stanza = stanzaResult;
         } else {
             this.stanza = null;
         }


### PR DESCRIPTION
Fixes #167 

Monitoring 2.2.0 enhanced some work on archiving full stanzas.
This fixes a bug where MAM requests attempts to use those stanza, not taking account for old archives that may have missing stanzas.