### PR TITLE
fixes #165: Guarantee sort order of results

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -47,6 +47,7 @@ Monitoring Plugin Changelog
 <p><b>2.2.1</b> -- (tbd)</p>
 <ul>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/157'>Issue #157</a>] - Poor MAM performance with large archives</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/165'>Issue #165</a>] - Fix ordering of MAM results</li>
 </ul>
 
 <p><b>2.2.0</b> -- January 6, 2021</p>

--- a/src/java/com/reucon/openfire/plugin/archive/impl/PaginatedMessageDatabaseQuery.java
+++ b/src/java/com/reucon/openfire/plugin/archive/impl/PaginatedMessageDatabaseQuery.java
@@ -29,6 +29,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
@@ -157,6 +158,9 @@ public class PaginatedMessageDatabaseQuery
             while (rs.next()) {
                 final ArchivedMessage archivedMessage = JdbcPersistenceManager.extractMessage(owner, rs);
                 archivedMessages.add(archivedMessage);
+            }
+            if(isPagingBackwards){
+                Collections.reverse(archivedMessages);
             }
         } catch (SQLException e) {
             Log.error("SQL failure during MAM for owner: {}", this.owner, e);

--- a/src/java/com/reucon/openfire/plugin/archive/impl/PaginatedMucMessageDatabaseQuery.java
+++ b/src/java/com/reucon/openfire/plugin/archive/impl/PaginatedMucMessageDatabaseQuery.java
@@ -29,6 +29,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
@@ -173,6 +174,9 @@ public class PaginatedMucMessageDatabaseQuery
             while (rs.next()) {
                 final ArchivedMessage archivedMessage = JdbcPersistenceManager.extractMessage(archiveOwner, rs);
                 archivedMessages.add(archivedMessage);
+            }
+            if(isPagingBackwards){
+                Collections.reverse(archivedMessages);
             }
         } catch (SQLException e) {
             Log.error("SQL failure during MUC MAM for room {}, message owner: {}", this.archiveOwner, this.messageOwner, e);


### PR DESCRIPTION
Fixes #165 

[This](https://github.com/igniterealtime/openfire-monitoring-plugin/commit/db634ebc0e1f28fdb835d8f23ef7795baf74fa83) commit, sorting has been reversed whenever a `<before>` is present in a MAM query.
Rather than reintroduce the subquery to enforce the sort, this adds a list sort after retrieving the records.

Presently, this is still an ordering that relies on timestamps (as it always did) but given the granularity of the timestamp, the risks described in [XEP-0313§3.1](https://xmpp.org/extensions/xep-0313.html#archive_order) remain a low probability.