### PR TITLE
fixes #175: Fix MySQL installation script

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -52,6 +52,7 @@ Monitoring Plugin Changelog
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/165'>Issue #165</a>] - Fix ordering of MAM results</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/167'>Issue #167</a>] - Deal with empty stanzas in db when processing MAM queries</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/174'>Issue #174</a>] - Upgrade jackson libraryto 2.12.1</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/175'>Issue #175</a>] - Fix database installation script for MySQL (bug introduced in 2.2.0 that affected new installations)</li>
 </ul>
 
 <p><b>2.2.0</b> -- January 6, 2021</p>

--- a/src/database/monitoring_db2.sql
+++ b/src/database/monitoring_db2.sql
@@ -1,5 +1,5 @@
 
-INSERT INTO ofVersion (name, version) VALUES ('monitoring', 7);
+INSERT INTO ofVersion (name, version) VALUES ('monitoring', 8);
 
 CREATE TABLE ofConversation (
   conversationID        INTEGER      NOT NULL,

--- a/src/database/monitoring_hsqldb.sql
+++ b/src/database/monitoring_hsqldb.sql
@@ -1,5 +1,5 @@
 
-INSERT INTO ofVersion (name, version) VALUES ('monitoring', 7);
+INSERT INTO ofVersion (name, version) VALUES ('monitoring', 8);
 
 CREATE TABLE ofConversation (
   conversationID        BIGINT        NOT NULL,

--- a/src/database/monitoring_mysql.sql
+++ b/src/database/monitoring_mysql.sql
@@ -1,5 +1,5 @@
 
-INSERT INTO ofVersion (name, version) VALUES ('monitoring', 7);
+INSERT INTO ofVersion (name, version) VALUES ('monitoring', 8);
 
 CREATE TABLE ofConversation (
   conversationID        BIGINT        NOT NULL,
@@ -35,7 +35,7 @@ CREATE TABLE ofMessageArchive (
    sentDate          BIGINT           NOT NULL,
    stanza			 TEXT			  NULL,
    body              TEXT             NULL,
-   isPMforJID        VARCHAR(255)     NOT NULL,
+   isPMforJID        VARCHAR(255)     NULL,
    INDEX ofMessageArchive_con_idx (conversationID),
    INDEX ofMessageArchive_fromjid_idx (fromJID),
    INDEX ofMessageArchive_tojid_idx (toJID),

--- a/src/database/monitoring_oracle.sql
+++ b/src/database/monitoring_oracle.sql
@@ -1,5 +1,5 @@
 
-INSERT INTO ofVersion (name, version) VALUES ('monitoring', 7);
+INSERT INTO ofVersion (name, version) VALUES ('monitoring', 8);
 
 CREATE TABLE ofConversation (
   conversationID        INTEGER        NOT NULL,

--- a/src/database/monitoring_postgresql.sql
+++ b/src/database/monitoring_postgresql.sql
@@ -1,5 +1,5 @@
 
-INSERT INTO ofVersion (name, version) VALUES ('monitoring', 7);
+INSERT INTO ofVersion (name, version) VALUES ('monitoring', 8);
 
 CREATE TABLE ofConversation (
   conversationID        INTEGER       NOT NULL,

--- a/src/database/monitoring_sqlserver.sql
+++ b/src/database/monitoring_sqlserver.sql
@@ -1,5 +1,5 @@
 
-INSERT INTO ofVersion (name, version) VALUES ('monitoring', 7);
+INSERT INTO ofVersion (name, version) VALUES ('monitoring', 8);
 
 CREATE TABLE ofConversation (
   conversationID        BIGINT         NOT NULL,

--- a/src/database/upgrade/8/monitoring_db2.sql
+++ b/src/database/upgrade/8/monitoring_db2.sql
@@ -1,0 +1,4 @@
+-- This is a MySQL-specific update.
+
+-- Update database version
+UPDATE ofVersion SET version = 8 WHERE name = 'monitoring';

--- a/src/database/upgrade/8/monitoring_hsqldb.sql
+++ b/src/database/upgrade/8/monitoring_hsqldb.sql
@@ -1,0 +1,4 @@
+-- This is a MySQL-specific update.
+
+-- Update database version
+UPDATE ofVersion SET version = 8 WHERE name = 'monitoring';

--- a/src/database/upgrade/8/monitoring_mysql.sql
+++ b/src/database/upgrade/8/monitoring_mysql.sql
@@ -1,0 +1,4 @@
+ALTER TABLE ofMessageArchive MODIFY COLUMN isPMforJID VARCHAR(255) NULL;
+
+-- Update database version
+UPDATE ofVersion SET version = 8 WHERE name = 'monitoring';

--- a/src/database/upgrade/8/monitoring_oracle.sql
+++ b/src/database/upgrade/8/monitoring_oracle.sql
@@ -1,0 +1,4 @@
+-- This is a MySQL-specific update.
+
+-- Update database version
+UPDATE ofVersion SET version = 8 WHERE name = 'monitoring';

--- a/src/database/upgrade/8/monitoring_postgresql.sql
+++ b/src/database/upgrade/8/monitoring_postgresql.sql
@@ -1,0 +1,4 @@
+-- This is a MySQL-specific update.
+
+-- Update database version
+UPDATE ofVersion SET version = 8 WHERE name = 'monitoring';

--- a/src/database/upgrade/8/monitoring_sqlserver.sql
+++ b/src/database/upgrade/8/monitoring_sqlserver.sql
@@ -1,0 +1,4 @@
+-- This is a MySQL-specific update.
+
+-- Update database version
+UPDATE ofVersion SET version = 8 WHERE name = 'monitoring';


### PR DESCRIPTION
The MySQL installation script was modified in release 2.2.0 to add a new column. This column should have been defined as NULL, but was defined as NOT NULL. The database update script (7) does is correctly (the problem only affects fresh installations that use the initial installation script).

This commit adds a new update script (number 8) that corrects the column definition for MySQL, and corrects the original installation script. It is otherwise a no-op for other databases.