### PR TITLE
fixes #192: Return results for keyword and participant(s) combination query

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -48,6 +48,7 @@ Monitoring Plugin Changelog
 <ul>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/125'>Issue #125</a>] - Combining keyword and date range makes search fail</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/190'>Issue #190</a>] - Allow code-update to force a reindexation</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/192'>Issue #192</a>] - Combining keyword and participant(s) makes search fail</li>
 </ul>
 
 <p><b>2.2.1</b> -- February 12, 2021</p>

--- a/src/java/org/jivesoftware/openfire/archive/ArchiveIndexer.java
+++ b/src/java/org/jivesoftware/openfire/archive/ArchiveIndexer.java
@@ -375,7 +375,7 @@ public class ArchiveIndexer extends org.jivesoftware.openfire.index.LuceneIndexe
         document.add(new StringField("external", String.valueOf(external), Field.Store.NO));
         document.add(new NumericDocValuesField("date", date.toEpochMilli()));
         for (JID jid : jids) {
-            document.add(new StringField("jid", jid.toString(), Field.Store.NO));
+            document.add(new StringField("jid", jid.toBareJID(), Field.Store.NO));
         }
         document.add(new TextField("text", text, Field.Store.NO));
         writer.addDocument(document);

--- a/src/java/org/jivesoftware/openfire/archive/ArchiveSearcher.java
+++ b/src/java/org/jivesoftware/openfire/archive/ArchiveSearcher.java
@@ -157,7 +157,7 @@ public class ArchiveSearcher {
             if (!participants.isEmpty()) {
                 if (participants.size() == 1) {
                     JID jid = participants.iterator().next().asBareJID();
-                    Query participantQuery = new QueryParser("jid", analyzer).parse(jid.toString());
+                    TermQuery participantQuery = new TermQuery(new Term("jid", jid.toBareJID()));
                     Log.debug( "... restricting to participant: {}", jid );
 
                     // Add this query to the existing query.
@@ -177,8 +177,8 @@ public class ArchiveSearcher {
 
                     Log.debug( "... restricting to participants: {} and {}", participant1, participant2 );
                     final BooleanQuery participantQuery = new BooleanQuery.Builder()
-                        .add(new QueryParser("jid", analyzer).parse(participant1), BooleanClause.Occur.MUST)
-                        .add(new QueryParser("jid", analyzer).parse(participant2), BooleanClause.Occur.MUST)
+                        .add(new TermQuery(new Term("jid", participant1)), BooleanClause.Occur.MUST)
+                        .add(new TermQuery(new Term("jid", participant2)), BooleanClause.Occur.MUST)
                         .build();
 
                     // Add this query to the existing query.


### PR DESCRIPTION
Using a term-based query for the JIDs of participants when searching through the Lucene index.