### PR TITLE
Optionally run conversation archive functionality on all cluster nodes separately

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -52,6 +52,7 @@ Monitoring Plugin Changelog
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/192'>Issue #192</a>] - Combining keyword and participant(s) makes search fail</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/195'>Issue #195</a>] - Class incompatibility with latest OF MUC</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/200'>Issue #200</a>] - Remove references to deprecated logger methods</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/202'>Issue #202</a>] - Make plugin compile against OF with new MUCEventListener method</li>
 </ul>
 
 <p><b>2.2.1</b> -- February 12, 2021</p>

--- a/changelog.html
+++ b/changelog.html
@@ -50,6 +50,7 @@ Monitoring Plugin Changelog
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/190'>Issue #190</a>] - Allow code-update to force a reindexation</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/192'>Issue #192</a>] - Combining keyword and participant(s) makes search fail</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/195'>Issue #195</a>] - Class incompatibility with latest OF MUC</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/200'>Issue #200</a>] - Remove references to deprecated logger methods</li>
 </ul>
 
 <p><b>2.2.1</b> -- February 12, 2021</p>

--- a/changelog.html
+++ b/changelog.html
@@ -46,6 +46,7 @@ Monitoring Plugin Changelog
 
 <p><b>2.2.2</b> -- (tbd)</p>
 <ul>
+    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/120'>Issue #120</a>] - Optionally not centralise conversation archiving on one single (senior) node, but process it on all separate nodes instead</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/125'>Issue #125</a>] - Combining keyword and date range makes search fail</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/190'>Issue #190</a>] - Allow code-update to force a reindexation</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/192'>Issue #192</a>] - Combining keyword and participant(s) makes search fail</li>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.7.0-beta</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>monitoring</artifactId>

--- a/src/java/com/reucon/openfire/plugin/archive/xep/AbstractXepSupport.java
+++ b/src/java/com/reucon/openfire/plugin/archive/xep/AbstractXepSupport.java
@@ -11,13 +11,20 @@ import org.jivesoftware.openfire.handler.IQHandler;
 import org.jivesoftware.openfire.muc.MultiUserChatManager;
 import org.jivesoftware.openfire.muc.MultiUserChatService;
 import org.jivesoftware.openfire.plugin.MonitoringPlugin;
-import org.jivesoftware.util.Log;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xmpp.packet.IQ;
 import org.xmpp.packet.PacketError;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
 
 public abstract class AbstractXepSupport implements UserFeaturesProvider {
+
+    private static final Logger Log = LoggerFactory.getLogger(AbstractXepSupport.class);
 
     protected final XMPPServer server;
     protected final Map<QName, IQHandler> element2Handlers;

--- a/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
+++ b/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
@@ -175,7 +175,7 @@ public class ConversationManager implements ComponentEventListener{
 
         maxAge = JiveGlobals.getIntProperty("conversation.maxAge", DEFAULT_MAX_AGE) * JiveConstants.DAY;
         maxRetrievable = JiveGlobals.getIntProperty("conversation.maxRetrievable", DEFAULT_MAX_RETRIEVABLE) * JiveConstants.DAY;
-        retrieveConversationsLocally = JiveGlobals.getBooleanProperty("conversation.retrieveLocally", true);
+        retrieveConversationsLocally = JiveGlobals.getBooleanProperty("conversation.retrieveLocally", false);
 
         // Listen for any changes to the conversation properties.
         propertyListener = new ConversationPropertyListener();

--- a/src/java/org/jivesoftware/openfire/archive/GroupConversationInterceptor.java
+++ b/src/java/org/jivesoftware/openfire/archive/GroupConversationInterceptor.java
@@ -55,7 +55,7 @@ public class GroupConversationInterceptor implements MUCEventListener {
     @Override
     public void roomDestroyed(JID roomJID) {
         // Process this event in the senior cluster member or local JVM when not in a cluster
-        if (ClusterManager.isSeniorClusterMember()) {
+        if (conversationManager.isRetrieveConversationsLocally() || ClusterManager.isSeniorClusterMember()) {
             conversationManager.roomConversationEnded(roomJID, new Date());
         }
         else {
@@ -68,7 +68,7 @@ public class GroupConversationInterceptor implements MUCEventListener {
     @Override
     public void occupantJoined(JID roomJID, JID user, String nickname) {
         // Process this event in the senior cluster member or local JVM when not in a cluster
-        if (ClusterManager.isSeniorClusterMember()) {
+        if (conversationManager.isRetrieveConversationsLocally() || ClusterManager.isSeniorClusterMember()) {
             conversationManager.joinedGroupConversation(roomJID, user, nickname, new Date());
         }
         else {
@@ -81,7 +81,7 @@ public class GroupConversationInterceptor implements MUCEventListener {
     @Override
     public void occupantLeft(JID roomJID, JID user, String nickname) {
         // Process this event in the senior cluster member or local JVM when not in a cluster
-        if (ClusterManager.isSeniorClusterMember()) {
+        if (conversationManager.isRetrieveConversationsLocally() || ClusterManager.isSeniorClusterMember()) {
             conversationManager.leftGroupConversation(roomJID, user, new Date());
             // If there are no more occupants then consider the group conversation over
             MUCRoom mucRoom = XMPPServer.getInstance().getMultiUserChatManager().getMultiUserChatService(roomJID).getChatRoom(roomJID.getNode());
@@ -99,7 +99,7 @@ public class GroupConversationInterceptor implements MUCEventListener {
     @Override
     public void nicknameChanged(JID roomJID, JID user, String oldNickname, String newNickname) {
         // Process this event in the senior cluster member or local JVM when not in a cluster
-        if (ClusterManager.isSeniorClusterMember()) {
+        if (conversationManager.isRetrieveConversationsLocally() || ClusterManager.isSeniorClusterMember()) {
             occupantLeft(roomJID, user, oldNickname);
             // Sleep 1 millisecond so that there is a delay between logging out and logging in
             try {
@@ -121,7 +121,7 @@ public class GroupConversationInterceptor implements MUCEventListener {
         final Date now = new Date();
 
         // Process this event in the senior cluster member or local JVM when not in a cluster
-        if (ClusterManager.isSeniorClusterMember()) {
+        if (conversationManager.isRetrieveConversationsLocally() || ClusterManager.isSeniorClusterMember()) {
             conversationManager.processRoomMessage(roomJID, user, null, nickname, message.getBody(), message.toXML(), now);
         }
         else {
@@ -141,7 +141,7 @@ public class GroupConversationInterceptor implements MUCEventListener {
             final JID roomJID = message.getFrom().asBareJID();
             final String senderNickname = message.getFrom().getResource();
             final Date now = new Date();
-            if (ClusterManager.isSeniorClusterMember()) {
+            if (conversationManager.isRetrieveConversationsLocally() || ClusterManager.isSeniorClusterMember()) {
                 if (JiveGlobals.getBooleanProperty("conversation.roomArchiving.PMinPersonalArchive", false)) {
                     // Historically, private messages are saved as regular 'one-on-one' messages.
                     conversationManager.processMessage(fromJID, toJID, message.getBody(), message.toXML(), now);

--- a/src/java/org/jivesoftware/openfire/archive/GroupConversationInterceptor.java
+++ b/src/java/org/jivesoftware/openfire/archive/GroupConversationInterceptor.java
@@ -48,6 +48,11 @@ public class GroupConversationInterceptor implements MUCEventListener {
     }
 
     @Override
+    public void occupantNickKicked(JID jid, String nickname) {
+        // Do nothing. This will result in users being removed from rooms, which should trigger an occupantLeft invocation for each room involved.
+    }
+
+    @Override
     public void roomDestroyed(JID roomJID) {
         // Process this event in the senior cluster member or local JVM when not in a cluster
         if (ClusterManager.isSeniorClusterMember()) {

--- a/src/java/org/jivesoftware/openfire/reporting/stats/StatsAction.java
+++ b/src/java/org/jivesoftware/openfire/reporting/stats/StatsAction.java
@@ -15,6 +15,22 @@
  */
 package org.jivesoftware.openfire.reporting.stats;
 
+import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.archive.Conversation;
+import org.jivesoftware.openfire.archive.ConversationManager;
+import org.jivesoftware.openfire.archive.MonitoringConstants;
+import org.jivesoftware.openfire.plugin.MonitoringPlugin;
+import org.jivesoftware.openfire.reporting.graph.GraphEngine;
+import org.jivesoftware.openfire.stats.Statistic;
+import org.jivesoftware.openfire.user.UserNameManager;
+import org.jivesoftware.openfire.user.UserNotFoundException;
+import org.jivesoftware.util.JiveGlobals;
+import org.jivesoftware.util.LocaleUtils;
+import org.jivesoftware.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xmpp.packet.JID;
+
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.text.DateFormat;
@@ -30,21 +46,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import org.jivesoftware.openfire.XMPPServer;
-import org.jivesoftware.openfire.archive.Conversation;
-import org.jivesoftware.openfire.archive.ConversationManager;
-import org.jivesoftware.openfire.archive.MonitoringConstants;
-import org.jivesoftware.openfire.plugin.MonitoringPlugin;
-import org.jivesoftware.openfire.reporting.graph.GraphEngine;
-import org.jivesoftware.openfire.stats.Statistic;
-import org.jivesoftware.openfire.user.UserNameManager;
-import org.jivesoftware.openfire.user.UserNotFoundException;
-import org.jivesoftware.util.JiveGlobals;
-import org.jivesoftware.util.LocaleUtils;
-import org.jivesoftware.util.Log;
-import org.jivesoftware.util.StringUtils;
-import org.xmpp.packet.JID;
-
 /**
  * Provides the server side callbacks for client side JavaScript functions for
  * the stats dashboard page.
@@ -52,6 +53,8 @@ import org.xmpp.packet.JID;
  * @author Aaron Johnson
  */
 public class StatsAction {
+
+    private static final Logger Log = LoggerFactory.getLogger(StatsAction.class);
 
     /**
      * Retrieves a map containing the high / low and current count statistics

--- a/src/web/archive-conversation-participants.jsp
+++ b/src/web/archive-conversation-participants.jsp
@@ -11,11 +11,15 @@
 <%@ page import="org.jivesoftware.util.StringUtils" %>
 <%@ page import="org.xmpp.packet.JID" %>
 <%@ page import="java.util.*" %>
+<%@ page import="org.slf4j.LoggerFactory" %>
+<%@ page import="org.slf4j.Logger" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
 <%
+    Logger logger = LoggerFactory.getLogger("archive-conversation-participants-jsp");
+    
     long conversationID = ParamUtils.getLongParameter(request, "conversationID", -1);
     int start = ParamUtils.getIntParameter(request, "start", 0);
 
@@ -47,7 +51,7 @@
         }
     }
     catch (NotFoundException e) {
-        Log.error("Conversation not found: " + conversationID, e);
+        logger.error("Conversation not found: " + conversationID, e);
     }
     // paginator vars
     int range = 16;

--- a/src/web/archive-search.jsp
+++ b/src/web/archive-search.jsp
@@ -12,10 +12,15 @@
 <%@ page import="java.text.DateFormat"%>
 <%@ page import="java.text.SimpleDateFormat" %>
 <%@ page import="java.util.*" %>
+<%@ page import="org.slf4j.Logger" %>
+<%@ page import="org.slf4j.LoggerFactory" %>
+<%@ page import="com.reucon.openfire.plugin.archive.xep.AbstractXepSupport" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%
+    Logger logger = LoggerFactory.getLogger("archive-search-jsp");
+
     // Get handle on the Monitoring plugin
     MonitoringPlugin plugin = (MonitoringPlugin) XMPPServer.getInstance().getPluginManager().getPlugin(
             "monitoring");
@@ -94,7 +99,7 @@
             }
             catch (Exception e) {
                 // TODO: mark as an error in the JSP instead of logging..
-                Log.error(e);
+                logger.error("Date range can't be established", e);
             }
         }
 
@@ -113,7 +118,7 @@
             }
             catch (Exception e) {
                 // TODO: mark as an error in the JSP instead of logging..
-                Log.error(e);
+                logger.error("Date range can't be established", e);
             }
         }
 
@@ -842,7 +847,7 @@
                 participants.put(identifier, jid);
             }
             catch (Exception e) {
-                Log.error(e);
+                LoggerFactory.getLogger("archive-search-jsp").error("Participants can't be collected", e);
             }
 
         }

--- a/src/web/conversation-viewer.jsp
+++ b/src/web/conversation-viewer.jsp
@@ -8,10 +8,14 @@
 <%@ page import="java.util.HashMap" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="org.jivesoftware.util.*"%><%@ page import="java.util.Collection"%>
+<%@ page import="org.slf4j.LoggerFactory" %>
+<%@ page import="org.slf4j.Logger" %>
 <%!
      Map<String, String> colorMap = new HashMap<String, String>();
 %>
 <%
+    Logger logger = LoggerFactory.getLogger("conversation-viewer-jsp");
+
     // Get handle on the Monitoring plugin
     MonitoringPlugin plugin = (MonitoringPlugin)XMPPServer.getInstance().getPluginManager().getPlugin(
         "monitoring");
@@ -26,7 +30,7 @@
             conversation = new Conversation(conversationManager, conversationID);
         }
         catch (NotFoundException nfe) {
-            Log.error(nfe);
+            logger.error("Can't reconstruct conversation", nfe);
         }
     }
 
@@ -86,7 +90,7 @@ No conversation could be found.
     String getColor(JID jid){
         String color = colorMap.get(jid.toBareJID());
         if(color == null){
-            Log.debug("Unable to find "+jid.toBareJID()+" using "+colorMap);
+            LoggerFactory.getLogger("conversation-viewer-jsp").debug("Unable to find "+jid.toBareJID()+" using "+colorMap);
         }
         return color;
     }


### PR DESCRIPTION
See #120. This PR adds the option (by configuration) to not centralise conversation archiving on one single (senior) node, but to process it on all separate nodes instead.