### PR TITLE
Optionally run conversation archive functionality on all cluster nodes separately

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -52,6 +52,7 @@ Monitoring Plugin Changelog
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/192'>Issue #192</a>] - Combining keyword and participant(s) makes search fail</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/195'>Issue #195</a>] - Class incompatibility with latest OF MUC</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/200'>Issue #200</a>] - Remove references to deprecated logger methods</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/202'>Issue #202</a>] - Make plugin compile against OF with new MUCEventListener method</li>
 </ul>
 
 <p><b>2.2.1</b> -- February 12, 2021</p>

--- a/changelog.html
+++ b/changelog.html
@@ -46,6 +46,7 @@ Monitoring Plugin Changelog
 
 <p><b>2.2.2</b> -- (tbd)</p>
 <ul>
+    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/120'>Issue #120</a>] - Optionally not centralise conversation archiving on one single (senior) node, but process it on all separate nodes instead</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/125'>Issue #125</a>] - Combining keyword and date range makes search fail</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/190'>Issue #190</a>] - Allow code-update to force a reindexation</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/192'>Issue #192</a>] - Combining keyword and participant(s) makes search fail</li>

--- a/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
+++ b/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
@@ -175,7 +175,7 @@ public class ConversationManager implements ComponentEventListener{
 
         maxAge = JiveGlobals.getIntProperty("conversation.maxAge", DEFAULT_MAX_AGE) * JiveConstants.DAY;
         maxRetrievable = JiveGlobals.getIntProperty("conversation.maxRetrievable", DEFAULT_MAX_RETRIEVABLE) * JiveConstants.DAY;
-        retrieveConversationsLocally = JiveGlobals.getBooleanProperty("conversation.retrieveLocally", true);
+        retrieveConversationsLocally = JiveGlobals.getBooleanProperty("conversation.retrieveLocally", false);
 
         // Listen for any changes to the conversation properties.
         propertyListener = new ConversationPropertyListener();

--- a/src/java/org/jivesoftware/openfire/archive/GroupConversationInterceptor.java
+++ b/src/java/org/jivesoftware/openfire/archive/GroupConversationInterceptor.java
@@ -55,7 +55,7 @@ public class GroupConversationInterceptor implements MUCEventListener {
     @Override
     public void roomDestroyed(JID roomJID) {
         // Process this event in the senior cluster member or local JVM when not in a cluster
-        if (ClusterManager.isSeniorClusterMember()) {
+        if (conversationManager.isRetrieveConversationsLocally() || ClusterManager.isSeniorClusterMember()) {
             conversationManager.roomConversationEnded(roomJID, new Date());
         }
         else {
@@ -68,7 +68,7 @@ public class GroupConversationInterceptor implements MUCEventListener {
     @Override
     public void occupantJoined(JID roomJID, JID user, String nickname) {
         // Process this event in the senior cluster member or local JVM when not in a cluster
-        if (ClusterManager.isSeniorClusterMember()) {
+        if (conversationManager.isRetrieveConversationsLocally() || ClusterManager.isSeniorClusterMember()) {
             conversationManager.joinedGroupConversation(roomJID, user, nickname, new Date());
         }
         else {
@@ -81,7 +81,7 @@ public class GroupConversationInterceptor implements MUCEventListener {
     @Override
     public void occupantLeft(JID roomJID, JID user, String nickname) {
         // Process this event in the senior cluster member or local JVM when not in a cluster
-        if (ClusterManager.isSeniorClusterMember()) {
+        if (conversationManager.isRetrieveConversationsLocally() || ClusterManager.isSeniorClusterMember()) {
             conversationManager.leftGroupConversation(roomJID, user, new Date());
             // If there are no more occupants then consider the group conversation over
             MUCRoom mucRoom = XMPPServer.getInstance().getMultiUserChatManager().getMultiUserChatService(roomJID).getChatRoom(roomJID.getNode());
@@ -99,7 +99,7 @@ public class GroupConversationInterceptor implements MUCEventListener {
     @Override
     public void nicknameChanged(JID roomJID, JID user, String oldNickname, String newNickname) {
         // Process this event in the senior cluster member or local JVM when not in a cluster
-        if (ClusterManager.isSeniorClusterMember()) {
+        if (conversationManager.isRetrieveConversationsLocally() || ClusterManager.isSeniorClusterMember()) {
             occupantLeft(roomJID, user, oldNickname);
             // Sleep 1 millisecond so that there is a delay between logging out and logging in
             try {
@@ -121,7 +121,7 @@ public class GroupConversationInterceptor implements MUCEventListener {
         final Date now = new Date();
 
         // Process this event in the senior cluster member or local JVM when not in a cluster
-        if (ClusterManager.isSeniorClusterMember()) {
+        if (conversationManager.isRetrieveConversationsLocally() || ClusterManager.isSeniorClusterMember()) {
             conversationManager.processRoomMessage(roomJID, user, null, nickname, message.getBody(), message.toXML(), now);
         }
         else {
@@ -141,7 +141,7 @@ public class GroupConversationInterceptor implements MUCEventListener {
             final JID roomJID = message.getFrom().asBareJID();
             final String senderNickname = message.getFrom().getResource();
             final Date now = new Date();
-            if (ClusterManager.isSeniorClusterMember()) {
+            if (conversationManager.isRetrieveConversationsLocally() || ClusterManager.isSeniorClusterMember()) {
                 if (JiveGlobals.getBooleanProperty("conversation.roomArchiving.PMinPersonalArchive", false)) {
                     // Historically, private messages are saved as regular 'one-on-one' messages.
                     conversationManager.processMessage(fromJID, toJID, message.getBody(), message.toXML(), now);

--- a/src/web/archive-search.jsp
+++ b/src/web/archive-search.jsp
@@ -14,7 +14,6 @@
 <%@ page import="java.util.*" %>
 <%@ page import="org.slf4j.Logger" %>
 <%@ page import="org.slf4j.LoggerFactory" %>
-<%@ page import="com.reucon.openfire.plugin.archive.xep.AbstractXepSupport" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>


### PR DESCRIPTION
See #120. This PR adds the option (by configuration) to not centralise conversation archiving on one single (senior) node, but to process it on all separate nodes instead.

This PR replaces #204, which became a bit of a git mess.