### PR TITLE
Fixes for 'conversations' page (when auto-updating)

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -51,6 +51,7 @@ Monitoring Plugin Changelog
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/192'>Issue #192</a>] - Combining keyword and participant(s) makes search fail</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/195'>Issue #195</a>] - Class incompatibility with latest OF MUC</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/200'>Issue #200</a>] - Remove references to deprecated logger methods</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/206'>Issue #206</a>] - Fixed auto-updates for 'Conversations' admin page</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/213'>Issue #213</a>] - Update iText library to 7.1.17</li>
 </ul>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
     <description>Monitors conversations and statistics of the server.</description>
     <author>Ignite Realtime</author>
     <version>${project.version}</version>
-    <date>08/11/2021</date>
+    <date>12/08/2021</date>
     <minServerVersion>4.7.0</minServerVersion>
     <minJavaVersion>1.8</minJavaVersion>
     <databaseKey>monitoring</databaseKey>

--- a/src/java/org/jivesoftware/openfire/archive/ConversationInfo.java
+++ b/src/java/org/jivesoftware/openfire/archive/ConversationInfo.java
@@ -25,9 +25,11 @@ public class ConversationInfo {
     private String participant1;
     private String participant2;
     /**
-     * For group converstion we need to send a string array with the occupants' JIDs.
+     * For group conversation we need to send a string array with the occupants' JIDs as well as the room JID.
      */
     private String[] allParticipants;
+    private String roomJID;
+
     private String date;
     private String lastActivity;
     private String body;
@@ -64,6 +66,14 @@ public class ConversationInfo {
 
     public void setAllParticipants(String[] allParticipants) {
         this.allParticipants = allParticipants;
+    }
+
+    public String getRoomJID() {
+        return roomJID;
+    }
+
+    public void setRoomJID(String roomJID) {
+        this.roomJID = roomJID;
     }
 
     public String getDate() {

--- a/src/java/org/jivesoftware/openfire/archive/ConversationUtils.java
+++ b/src/java/org/jivesoftware/openfire/archive/ConversationUtils.java
@@ -271,6 +271,7 @@ public class ConversationUtils {
                 jids[i] = formatJID(formatParticipants, occupants[i]);
             }
             info.setAllParticipants(jids);
+            info.setRoomJID(conversation.getRoom().toBareJID());
         }
 
         Map<String, String> cssLabels = new HashMap<String, String>();

--- a/src/web/conversations.jsp
+++ b/src/web/conversations.jsp
@@ -51,22 +51,24 @@ function updateConversations(data) {
     conversationsTable = $('conversations');
     rows = conversationsTable.getElementsByTagName("tr");
     // loop over existing rows in the table
-    var rowsToDelete = new Array();
+    var rowsToDelete = [];
     for (i = 0; i < rows.length; i++) {
         // is this a conversation row?
-        if (rows[i].id == 'noconversations') {
+        if (rows[i].id === 'noconversations') {
             rowsToDelete.push(i);
-        } else if (rows[i].id != '') {
+        } else if (rows[i].id !== '') {
             // does the conversation exist in update we received?
             convID = rows[i].id.replace('conversation-', '');
-            if (data[convID] != undefined) {
+            if (data[convID] !== undefined) {
 
                 row = rows[i];
                 cells = row.getElementsByTagName('td');
                 conversation = data[convID];
-                if (cells[3].innerHTML != conversation.messageCount) {
-                    users = conversation.participant1 + '<br />' + conversation.participant2;
-                    cells[0].innerHTML = users;
+                if (cells[3].innerHTML !== conversation.messageCount) {
+                    if (!conversation.allParticipants) {
+                        users = conversation.participant1 + '<br />' + conversation.participant2;
+                        cells[0].innerHTML = users;
+                    }
                     cells[1].innerHTML = conversation.duration;
                     cells[2].innerHTML = conversation.lastActivity;
                     cells[3].innerHTML = conversation.messageCount;
@@ -89,9 +91,15 @@ function updateConversations(data) {
     for (var c in data) {
         counter++;
         // does this conversation already exist?
-        if ($('conversation-' + c) == undefined) {
+        if (!$('conversation-' + c)) {
             conversation = data[c];
-            users = conversation.participant1 + '<br />' + conversation.participant2;
+            if (!conversation.allParticipants) {
+                users = conversation.participant1 + '<br />' + conversation.participant2;
+            } else {
+                users = '<fmt:message key="archive.group_conversation"/>';
+                users = users.replace('{0}', '<a href="../../muc-room-occupants.jsp?roomJID=' + conversation.roomJID + '">');
+                users = users.replace('{1}', '</a');
+            }
             var newTR = document.createElement("tr");
             newTR.setAttribute('id', 'conversation-' + c)
             conversationsTable.appendChild(newTR);
@@ -115,6 +123,17 @@ function updateConversations(data) {
 
     // update activeConversations number
     $('activeConversations').innerHTML = counter;
+
+    // When there's no data in the table, add the 'no conversations' placeholder.
+    if (counter === 0 && !document.getElementById('noconversations')) {
+        var noConvTR = document.createElement("tr");
+        noConvTR.setAttribute('id', 'noconversations');
+        conversationsTable.appendChild(noConvTR);
+        var noConvTD = document.createElement("TD")
+        noConvTD.setAttribute('colspan', '4');
+        noConvTD.innerHTML = '<fmt:message key="archive.converations.no_conversations" />';
+        noConvTR.appendChild(noConvTD);
+    }
 }
 
 //# sourceURL=conversations.jsp


### PR DESCRIPTION
The admin page that shows active conversations should properly display group chats after an automatic update of its content.

When no conversations are active any more, then the table should contain a message to that effect.

fixes #206