### PR TITLE
Properly display conversations on junior node after plugin reload

### DIFF
--- a/src/java/org/jivesoftware/openfire/archive/Conversation.java
+++ b/src/java/org/jivesoftware/openfire/archive/Conversation.java
@@ -641,6 +641,10 @@ public class Conversation implements Externalizable {
     }
 
     public void writeExternal(ObjectOutput out) throws IOException {
+        // ClassCastExceptions occur when using classes provided by a plugin during serialization (sometimes only after
+        // reloading the plugin without restarting Openfire. This is why this implementation marshalls data as XML when
+        // serializing. See https://github.com/igniterealtime/openfire-monitoring-plugin/issues/120
+        // and https://github.com/igniterealtime/openfire-monitoring-plugin/issues/156
         ExternalizableUtil.getInstance().writeLong(out, conversationID);
         ExternalizableUtil.getInstance().writeInt(out, participants.size());
         for (Map.Entry<String, UserParticipations> e :  participants.entrySet()) {
@@ -658,6 +662,10 @@ public class Conversation implements Externalizable {
     }
 
     public void readExternal(ObjectInput in) throws IOException {
+        // ClassCastExceptions occur when using classes provided by a plugin during serialization (sometimes only after
+        // reloading the plugin without restarting Openfire. This is why this implementation marshalls data as XML when
+        // serializing. See https://github.com/igniterealtime/openfire-monitoring-plugin/issues/120
+        // and https://github.com/igniterealtime/openfire-monitoring-plugin/issues/156
         final Optional<Plugin> plugin = XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.PLUGIN_NAME);
         if (!plugin.isPresent()) {
             throw new IllegalStateException("Unable to handle IQ stanza. The Monitoring plugin does not appear to be loaded on this machine.");

--- a/src/java/org/jivesoftware/openfire/archive/Conversation.java
+++ b/src/java/org/jivesoftware/openfire/archive/Conversation.java
@@ -611,8 +611,9 @@ public class Conversation implements Externalizable {
 
     /**
      * Convert the conversation to an XML representation.
+     *
      * @return XML representation of the conversation.
-     * @throws IOException
+     * @throws IOException On any issue that occurs when marshalling this instance to XML.
      */
     public String toXml() throws IOException {
         return ConversationManager.getXmlSerializer().marshall(this);
@@ -620,15 +621,18 @@ public class Conversation implements Externalizable {
 
     /**
      * Create a new conversation object based on the XML representation.
+     *
      * @param xmlString The XML representation.
      * @return A newly instantiated conversation object containing state as included in the XML representation.
-     * @throws IOException
+     * @throws IOException On any issue that occurs when unmarshalling XML to an instance of Conversation.
      */
     public static Conversation fromXml(final String xmlString) throws IOException {
         final Conversation unmarshalled = (Conversation) ConversationManager.getXmlSerializer().unmarshall(xmlString);
         final Optional<Plugin> plugin = XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.PLUGIN_NAME);
         if (!plugin.isPresent()) {
-            throw new IllegalStateException("Unable to handle IQ stanza. The Monitoring plugin does not appear to be loaded on this machine.");
+            // Highly unlikely, as this code is _part_ of the Monitoring plugin. If this occurs something is very wrong.
+            throw new IOException("Unable to deserialize data as a Conversations instance: " + xmlString,
+                new IllegalStateException("The Monitoring plugin does not appear to be loaded on this machine."));
         }
         unmarshalled.conversationManager = ((MonitoringPlugin)plugin.get()).getConversationManager();
         return unmarshalled;

--- a/src/java/org/jivesoftware/openfire/archive/Conversation.java
+++ b/src/java/org/jivesoftware/openfire/archive/Conversation.java
@@ -634,7 +634,9 @@ public class Conversation implements Externalizable {
             throw new IOException("Unable to deserialize data as a Conversations instance: " + xmlString,
                 new IllegalStateException("The Monitoring plugin does not appear to be loaded on this machine."));
         }
-        unmarshalled.conversationManager = ((MonitoringPlugin)plugin.get()).getConversationManager();
+        if (unmarshalled != null) {
+            unmarshalled.conversationManager = ((MonitoringPlugin) plugin.get()).getConversationManager();
+        }
         return unmarshalled;
     }
 

--- a/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
+++ b/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
@@ -1123,7 +1123,7 @@ public class ConversationManager implements ComponentEventListener{
      * Returns an XML serializer that can be used to marshall and unmarshall conversation objects.
      * @return The XML serializer.
      */
-    public static XmlSerializer getXmlSerializer() {
+    public static synchronized XmlSerializer getXmlSerializer() {
         if (ConversationManager.xmlSerializer == null) {
             ConversationManager.xmlSerializer = new XmlSerializer(
                 Conversation.class,

--- a/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
+++ b/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
@@ -563,9 +563,6 @@ public class ConversationManager implements ComponentEventListener{
      */
     public Collection<Conversation> getConversations() {
         if (ClusterManager.isSeniorClusterMember()) {
-
-            Log.debug("All conversations: {}", conversations);
-
             List<Conversation> conversationList = new ArrayList<Conversation>(conversations.values());
             // Sort the conversations by creation date.
             Collections.sort(conversationList, new Comparator<Conversation>() {

--- a/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
+++ b/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
@@ -112,7 +112,7 @@ public class ConversationManager implements ComponentEventListener{
     private static XmlSerializer xmlSerializer;
 
 
-    private Map<String, Conversation> conversations = new ConcurrentHashMap<String, Conversation>();
+    private Map<String, Conversation> conversations = new ConcurrentHashMap<>();
     private boolean metadataArchivingEnabled;
     /**
      * Flag that indicates if messages of one-to-one chats should be archived.
@@ -150,7 +150,7 @@ public class ConversationManager implements ComponentEventListener{
 
     public ConversationManager(TaskEngine taskEngine) {
         this.taskEngine = taskEngine;
-        this.gateways = new CopyOnWriteArrayList<String>();
+        this.gateways = new CopyOnWriteArrayList<>();
         this.serverInfo = XMPPServer.getInstance().getServerInfo();
         this.conversationEventsQueue = new ConversationEventsQueue(this, taskEngine);
     }
@@ -179,7 +179,7 @@ public class ConversationManager implements ComponentEventListener{
         propertyListener = new ConversationPropertyListener();
         PropertyEventDispatcher.addListener(propertyListener);
 
-        conversationListeners = new CopyOnWriteArraySet<ConversationListener>();
+        conversationListeners = new CopyOnWriteArraySet<>();
 
         conversationArchiver = new ConversationArchivingRunnable( "MonitoringPlugin Conversations" );
         messageArchiver = new MessageArchivingRunnable( "MonitoringPlugin Messages" );
@@ -563,7 +563,7 @@ public class ConversationManager implements ComponentEventListener{
      */
     public Collection<Conversation> getConversations() {
         if (ClusterManager.isSeniorClusterMember()) {
-            List<Conversation> conversationList = new ArrayList<Conversation>(conversations.values());
+            List<Conversation> conversationList = new ArrayList<>(conversations.values());
             // Sort the conversations by creation date.
             Collections.sort(conversationList, new Comparator<Conversation>() {
                 public int compare(Conversation c1, Conversation c2) {
@@ -683,7 +683,7 @@ public class ConversationManager implements ComponentEventListener{
             Conversation conversation = conversations.get(conversationKey);
             // Create a new conversation if necessary.
             if (conversation == null) {
-                Collection<JID> participants = new ArrayList<JID>(2);
+                Collection<JID> participants = new ArrayList<>(2);
                 participants.add(sender);
                 participants.add(receiver);
                 XMPPServer server = XMPPServer.getInstance();
@@ -706,7 +706,7 @@ public class ConversationManager implements ComponentEventListener{
                     || (date.getTime() - conversation.getStartDate().getTime() > maxTime)) {
                 removeConversation(conversationKey, conversation, conversation.getLastActivity());
 
-                Collection<JID> participants = new ArrayList<JID>(2);
+                Collection<JID> participants = new ArrayList<>(2);
                 participants.add(sender);
                 participants.add(receiver);
                 XMPPServer server = XMPPServer.getInstance();

--- a/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
+++ b/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
@@ -565,11 +565,7 @@ public class ConversationManager implements ComponentEventListener{
         if (ClusterManager.isSeniorClusterMember()) {
             List<Conversation> conversationList = new ArrayList<>(conversations.values());
             // Sort the conversations by creation date.
-            Collections.sort(conversationList, new Comparator<Conversation>() {
-                public int compare(Conversation c1, Conversation c2) {
-                    return c1.getStartDate().compareTo(c2.getStartDate());
-                }
-            });
+            conversationList.sort(Comparator.comparing(Conversation::getStartDate));
             return conversationList;
         } else {
             // Get this info from the senior cluster member when running in a cluster

--- a/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
+++ b/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
@@ -518,7 +518,7 @@ public class ConversationManager implements ComponentEventListener{
         if (ClusterManager.isSeniorClusterMember()) {
             return conversations.size();
         }
-        return (Integer) CacheFactory.doSynchronousClusterTask(new GetConversationCountTask(), ClusterManager.getSeniorClusterMember().toByteArray());
+        return CacheFactory.doSynchronousClusterTask(new GetConversationCountTask(), ClusterManager.getSeniorClusterMember().toByteArray());
     }
 
     /**
@@ -542,7 +542,7 @@ public class ConversationManager implements ComponentEventListener{
             return new Conversation(this, conversationID);
         } else {
             // Get this info from the senior cluster member when running in a cluster
-            String conversationXml = (String) CacheFactory.doSynchronousClusterTask(new GetConversationTask(conversationID), ClusterManager
+            String conversationXml = CacheFactory.doSynchronousClusterTask(new GetConversationTask(conversationID), ClusterManager
                     .getSeniorClusterMember().toByteArray());
             if (conversationXml == null) {
                 throw new NotFoundException("Conversation not found: " + conversationID);
@@ -573,7 +573,7 @@ public class ConversationManager implements ComponentEventListener{
             return conversationList;
         } else {
             // Get this info from the senior cluster member when running in a cluster
-            Collection<String> conversationXmls = (Collection<String>) CacheFactory.doSynchronousClusterTask(new GetConversationsTask(), ClusterManager
+            Collection<String> conversationXmls = CacheFactory.doSynchronousClusterTask(new GetConversationsTask(), ClusterManager
                     .getSeniorClusterMember().toByteArray());
             Collection<Conversation> result = new ArrayList<>();
             for (String conversationXml : conversationXmls) {

--- a/src/java/org/jivesoftware/openfire/archive/ConversationParticipation.java
+++ b/src/java/org/jivesoftware/openfire/archive/ConversationParticipation.java
@@ -18,6 +18,8 @@ package org.jivesoftware.openfire.archive;
 
 import org.jivesoftware.util.cache.ExternalizableUtil;
 
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
 import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -31,9 +33,13 @@ import java.util.Date;
  *
  * @author Gaston Dombiak
  */
+@XmlRootElement
 public class ConversationParticipation implements Externalizable {
+    @XmlElement
     private Date joined = new Date();
+    @XmlElement
     private Date left;
+    @XmlElement
     private String nickname;
 
     public ConversationParticipation() {

--- a/src/java/org/jivesoftware/openfire/archive/UserParticipations.java
+++ b/src/java/org/jivesoftware/openfire/archive/UserParticipations.java
@@ -78,6 +78,10 @@ public class UserParticipations implements Externalizable {
     }
 
     public void writeExternal(ObjectOutput out) throws IOException {
+        // ClassCastExceptions occur when using classes provided by a plugin during serialization (sometimes only after
+        // reloading the plugin without restarting Openfire. This is why this implementation marshalls data as XML when
+        // serializing. See https://github.com/igniterealtime/openfire-monitoring-plugin/issues/120
+        // and https://github.com/igniterealtime/openfire-monitoring-plugin/issues/156
         ExternalizableUtil.getInstance().writeBoolean(out, roomParticipation);
         ExternalizableUtil.getInstance().writeInt(out, participations.size());
         for (ConversationParticipation cp :  participations) {
@@ -86,12 +90,16 @@ public class UserParticipations implements Externalizable {
     }
 
     public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        // ClassCastExceptions occur when using classes provided by a plugin during serialization (sometimes only after
+        // reloading the plugin without restarting Openfire. This is why this implementation marshalls data as XML when
+        // serializing. See https://github.com/igniterealtime/openfire-monitoring-plugin/issues/120
+        // and https://github.com/igniterealtime/openfire-monitoring-plugin/issues/156
         roomParticipation = ExternalizableUtil.getInstance().readBoolean(in);
         if (roomParticipation) {
-            participations = new ArrayList<ConversationParticipation>();
+            participations = new ArrayList<>();
         }
         else {
-            participations = new CopyOnWriteArrayList<ConversationParticipation>();
+            participations = new CopyOnWriteArrayList<>();
         }
         int participationCount = ExternalizableUtil.getInstance().readInt(in);
         for (int i = 0; i < participationCount; i++) {

--- a/src/java/org/jivesoftware/openfire/archive/XmlSerializer.java
+++ b/src/java/org/jivesoftware/openfire/archive/XmlSerializer.java
@@ -43,7 +43,7 @@ import java.util.stream.Stream;
  */
 public class XmlSerializer {
     private static final Logger Log = LoggerFactory.getLogger(XmlSerializer.class);
-    private static final Class[] defaultClassesToBind = {
+    private static final Class<?>[] defaultClassesToBind = {
         ArrayList.class,
         HashMap.class,
         HashSet.class,
@@ -54,8 +54,8 @@ public class XmlSerializer {
     private final Unmarshaller unmarshaller;
 
     public XmlSerializer(Class<?>... classesToBind) {
-        final Class[] allClassesToBind = Stream.concat(Arrays.stream(defaultClassesToBind), Arrays.stream(classesToBind))
-            .toArray(size -> (Class[]) Array.newInstance(Class.class, size));
+        final Class<?>[] allClassesToBind = Stream.concat(Arrays.stream(defaultClassesToBind), Arrays.stream(classesToBind))
+            .toArray(size -> (Class<?>[]) Array.newInstance(Class.class, size));
 
         Log.trace("Binding classes: {}", allClassesToBind);
 

--- a/src/java/org/jivesoftware/openfire/archive/XmlSerializer.java
+++ b/src/java/org/jivesoftware/openfire/archive/XmlSerializer.java
@@ -26,6 +26,7 @@ import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
 import javax.xml.bind.annotation.adapters.XmlAdapter;
+import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.lang.reflect.Array;
@@ -69,11 +70,13 @@ public class XmlSerializer {
 
     /**
      * Convert some object to its XML representation.
+     *
      * @param object The object to convert.
      * @return The resulting XML representation.
+     * @throws IOException On any issue that occurs when marshalling this instance to XML.
      */
     @Nonnull
-    public String marshall(@Nullable Object object) {
+    public String marshall(@Nullable Object object) throws IOException {
         if (object == null) {
             return "";
         } else {
@@ -82,8 +85,7 @@ public class XmlSerializer {
             try {
                 this.marshaller.marshal(object, writer);
             } catch (JAXBException e) {
-                Log.error("Object could not be marshalled into an XML format: " + object, e);
-                throw new IllegalArgumentException("Object could not be marshalled into an XML format: " + object);
+                throw new IOException("Object could not be marshalled into an XML format: " + object, e);
             }
 
             return writer.toString();
@@ -96,15 +98,14 @@ public class XmlSerializer {
      * @return The resulting object.
      */
     @Nullable
-    public Object unmarshall(@Nullable String object) {
+    public Object unmarshall(@Nullable String object) throws IOException {
         if (object != null && !"".equals(object)) {
             StringReader reader = new StringReader(object);
 
             try {
                 return this.unmarshaller.unmarshal(reader);
             } catch (JAXBException e) {
-                Log.error("XML value could not be unmarshalled into an object: " + object, e);
-                throw new IllegalArgumentException("XML value could not be unmarshalled into an object: " + object);
+                throw new IOException("XML value could not be unmarshalled into an object: " + object, e);
             }
         } else {
             return null;

--- a/src/java/org/jivesoftware/openfire/archive/XmlSerializer.java
+++ b/src/java/org/jivesoftware/openfire/archive/XmlSerializer.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -57,14 +58,14 @@ public class XmlSerializer {
         final Class<?>[] allClassesToBind = Stream.concat(Arrays.stream(defaultClassesToBind), Arrays.stream(classesToBind))
             .toArray(size -> (Class<?>[]) Array.newInstance(Class.class, size));
 
-        Log.trace("Binding classes: {}", allClassesToBind);
+        Log.trace("Binding classes: {}", Arrays.stream(allClassesToBind).map(Class::toString).collect(Collectors.joining(", ")));
 
         try {
             JAXBContext jaxbContext = JAXBContext.newInstance(allClassesToBind);
             this.marshaller = jaxbContext.createMarshaller();
             this.unmarshaller = jaxbContext.createUnmarshaller();
         } catch (JAXBException e) {
-            throw new IllegalArgumentException("Unable to create xml serializer using classes " + allClassesToBind, e);
+            throw new IllegalArgumentException("Unable to create xml serializer using classes " + Arrays.stream(allClassesToBind).map(Class::toString).collect(Collectors.joining(", ")), e);
         }
     }
 

--- a/src/java/org/jivesoftware/openfire/archive/cluster/GetConversationTask.java
+++ b/src/java/org/jivesoftware/openfire/archive/cluster/GetConversationTask.java
@@ -68,7 +68,7 @@ public class GetConversationTask implements ClusterTask<String>
         try {
             conversationXml = conversationManager.getConversation(conversationID).toXml();
         } catch (NotFoundException | IOException e) {
-            // Ignore. The requester of this task will throw this exception in his JVM
+            Log.debug("Exception occurred while running GetConversationTask.", e);
         }
     }
 

--- a/src/java/org/jivesoftware/openfire/archive/cluster/GetConversationTask.java
+++ b/src/java/org/jivesoftware/openfire/archive/cluster/GetConversationTask.java
@@ -66,6 +66,10 @@ public class GetConversationTask implements ClusterTask<String>
         }
         final ConversationManager conversationManager = ((MonitoringPlugin)plugin.get()).getConversationManager();
         try {
+            // ClassCastExceptions occur when using classes provided by a plugin during serialization (sometimes only after
+            // reloading the plugin without restarting Openfire. This is why this implementation marshalls data as XML when
+            // serializing. See https://github.com/igniterealtime/openfire-monitoring-plugin/issues/120
+            // and https://github.com/igniterealtime/openfire-monitoring-plugin/issues/156
             conversationXml = conversationManager.getConversation(conversationID).toXml();
         } catch (NotFoundException | IOException e) {
             Log.debug("Exception occurred while running GetConversationTask.", e);

--- a/src/java/org/jivesoftware/openfire/archive/cluster/GetConversationsTask.java
+++ b/src/java/org/jivesoftware/openfire/archive/cluster/GetConversationsTask.java
@@ -61,6 +61,10 @@ public class GetConversationsTask implements ClusterTask<Collection<String>>
         final ConversationManager conversationManager = ((MonitoringPlugin)plugin.get()).getConversationManager();
         final Collection<Conversation> conversations = conversationManager.getConversations();
         try {
+            // ClassCastExceptions occur when using classes provided by a plugin during serialization (sometimes only after
+            // reloading the plugin without restarting Openfire. This is why this implementation marshalls data as XML when
+            // serializing. See https://github.com/igniterealtime/openfire-monitoring-plugin/issues/120
+            // and https://github.com/igniterealtime/openfire-monitoring-plugin/issues/156
             conversationsXml = new ArrayList<>();
             for (Conversation conversation : conversations) {
                 conversationsXml.add(conversation.toXml());

--- a/src/java/org/jivesoftware/openfire/archive/cluster/GetConversationsTask.java
+++ b/src/java/org/jivesoftware/openfire/archive/cluster/GetConversationsTask.java
@@ -66,7 +66,7 @@ public class GetConversationsTask implements ClusterTask<Collection<String>>
                 conversationsXml.add(conversation.toXml());
             }
         } catch (IOException e) {
-            // Ignore. The requester of this task will throw this exception in his JVM
+            Log.debug("Exception occurred while running GetConversationsTask.", e);
         }
     }
 

--- a/src/java/org/jivesoftware/openfire/archive/cluster/SendConversationEventsTask.java
+++ b/src/java/org/jivesoftware/openfire/archive/cluster/SendConversationEventsTask.java
@@ -77,6 +77,10 @@ public class SendConversationEventsTask implements ClusterTask<Void> {
     }
 
     public void writeExternal(ObjectOutput out) throws IOException {
+        // ClassCastExceptions occur when using classes provided by a plugin during serialization (sometimes only after
+        // reloading the plugin without restarting Openfire. This is why this implementation marshalls data as XML when
+        // serializing. See https://github.com/igniterealtime/openfire-monitoring-plugin/issues/120
+        // and https://github.com/igniterealtime/openfire-monitoring-plugin/issues/156
         ExternalizableUtil.getInstance().writeInt(out, events.size());
         for (ConversationEvent event : events) {
             ExternalizableUtil.getInstance().writeSafeUTF(out, ConversationManager.getXmlSerializer().marshall(event));
@@ -84,6 +88,10 @@ public class SendConversationEventsTask implements ClusterTask<Void> {
     }
 
     public void readExternal(ObjectInput in) throws IOException {
+        // ClassCastExceptions occur when using classes provided by a plugin during serialization (sometimes only after
+        // reloading the plugin without restarting Openfire. This is why this implementation marshalls data as XML when
+        // serializing. See https://github.com/igniterealtime/openfire-monitoring-plugin/issues/120
+        // and https://github.com/igniterealtime/openfire-monitoring-plugin/issues/156
         events = new ArrayList<>();
         int eventCount = ExternalizableUtil.getInstance().readInt(in);
         for (int i = 0; i < eventCount; i++) {


### PR DESCRIPTION
This PR fixes #120 and #170.

Cluster tasks of this plugin now contain String representations of conversations, instead of of the Conversation objects themselves. This prevents the class loading errors observed in #120 and #170. Furthermore, this prevents similar problems that occured after the plugin was reloaded on one of the nodes.