### PR TITLE
fixes #162: handle plugin unavailable

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -47,6 +47,7 @@ Monitoring Plugin Changelog
 <p><b>2.2.2</b> -- (tbd)</p>
 <ul>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/125'>Issue #125</a>] - Combining keyword and date range makes search fail</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/162'>Issue #162</a>] - Admin console pages should not break when not all cluster nodes have (the same) version of the plugin loaded</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/163'>Issue #163</a>] - Migrate Jive Globals to System Properties</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/190'>Issue #190</a>] - Allow code-update to force a reindexation</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/192'>Issue #192</a>] - Combining keyword and participant(s) makes search fail</li>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
     <description>Monitors conversations and statistics of the server.</description>
     <author>Ignite Realtime</author>
     <version>${project.version}</version>
-    <date>12/08/2021</date>
+    <date>12/23/2021</date>
     <minServerVersion>4.7.0</minServerVersion>
     <minJavaVersion>1.8</minJavaVersion>
     <databaseKey>monitoring</databaseKey>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.7.0-beta</version>
+        <version>4.7.0-SNAPSHOT</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>monitoring</artifactId>

--- a/src/i18n/monitoring_i18n.properties
+++ b/src/i18n/monitoring_i18n.properties
@@ -244,5 +244,6 @@ muc.conversation.joined={0} ({1}) has joined the room
 muc.conversation.left={0} ({1}) has left the room
 
 warning.httpbinding.disabled=The HTTP Binding service appears to be disabled! Web-based logs will not be accessible without this service. {0}Please enable the HTTP Binding service here!{1}
+warning.clustering.versions=This Openfire server is part of a cluster. Not all servers in the cluster are running (the same version of) the Monitoring plugin. This will result in inconsistent behavior, possibly even errors. Please review {0}the version of the Monitoring plugin that is installed on each cluster node.{1}
 
 monitoring.search.allow-unrecognized-fields=If 'true', silently ignores unrecognized search filters in queries, which otherwise result in error responses.

--- a/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
+++ b/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
@@ -570,7 +570,13 @@ public class ConversationManager implements ComponentEventListener{
         if (ClusterManager.isSeniorClusterMember()) {
             return conversations.size();
         }
-        return CacheFactory.doSynchronousClusterTask(new GetConversationCountTask(), ClusterManager.getSeniorClusterMember().toByteArray());
+        final Integer count = CacheFactory.doSynchronousClusterTask(new GetConversationCountTask(), ClusterManager.getSeniorClusterMember().toByteArray());
+        if (count == null) {
+            Log.warn("Unable to obtain conversation count from senior cluster member. Is (the same version of) the Monitoring Plugin running there?");
+            return -1;
+        } else {
+            return count;
+        }
     }
 
     /**
@@ -624,14 +630,18 @@ public class ConversationManager implements ComponentEventListener{
             Collection<String> conversationXmls = CacheFactory.doSynchronousClusterTask(new GetConversationsTask(), ClusterManager
                     .getSeniorClusterMember().toByteArray());
             Collection<Conversation> result = new ArrayList<>();
-            for (String conversationXml : conversationXmls) {
-                try {
-                    Log.debug("Interpreting conversation from: {}", conversationXml);
-                    final Conversation conversation = Conversation.fromXml(conversationXml);
-                    Log.debug("Interpreted conversation: {}", conversation);
-                    result.add(conversation);
-                } catch (IOException e) {
-                    Log.warn("Conversation could not be reconstructed from '{}' because of '{}'. This conversation is not included in the result set.", conversationXml, e.getMessage());
+            if (conversationXmls == null) {
+                Log.warn("Unable to obtain conversations from senior cluster member. Is (the same version of) the Monitoring Plugin running there?");
+            } else {
+                for (String conversationXml : conversationXmls) {
+                    try {
+                        Log.debug("Interpreting conversation from: {}", conversationXml);
+                        final Conversation conversation = Conversation.fromXml(conversationXml);
+                        Log.debug("Interpreted conversation: {}", conversation);
+                        result.add(conversation);
+                    } catch (IOException e) {
+                        Log.warn("Conversation could not be reconstructed from '{}' because of '{}'. This conversation is not included in the result set.", conversationXml, e.getMessage());
+                    }
                 }
             }
             return result;

--- a/src/web/archive-search.jsp
+++ b/src/web/archive-search.jsp
@@ -1,9 +1,5 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page errorPage="/error.jsp" import="org.jivesoftware.openfire.plugin.MonitoringPlugin"%>
-<%@ page import="org.jivesoftware.openfire.archive.ArchiveSearch" %>
-<%@ page import="org.jivesoftware.openfire.archive.ArchiveSearcher" %>
-<%@ page import="org.jivesoftware.openfire.archive.Conversation" %>
-<%@ page import="org.jivesoftware.openfire.archive.ConversationManager" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer" %>
 <%@ page import="org.jivesoftware.openfire.user.UserNameManager" %>
 <%@ page import="org.jivesoftware.openfire.user.UserNotFoundException" %>
@@ -15,6 +11,8 @@
 <%@ page import="org.slf4j.Logger" %>
 <%@ page import="org.slf4j.LoggerFactory" %>
 <%@ page import="com.reucon.openfire.plugin.archive.xep.AbstractXepSupport" %>
+<%@ page import="org.jivesoftware.openfire.archive.*" %>
+<%@ page import="org.jivesoftware.openfire.cluster.ClusterManager" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -498,6 +496,16 @@
 </style>
 </head>
 <body>
+
+<% if (!ClusterManager.findRemotePluginsWithDifferentVersion(MonitoringConstants.PLUGIN_NAME).isEmpty()) { %>
+<div class="warning">
+    <fmt:message key="warning.clustering.versions">
+        <fmt:param value="<a href='/system-clustering.jsp'>" />
+        <fmt:param value="</a>" />
+    </fmt:message>
+</div>
+<br/>
+<% } %>
 
 <a href="archive-conversation-participants.jsp?conversationID=" id="lbmessage" title="<fmt:message key="archive.group_conversation.participants" />" style="display:none;"></a>
 

--- a/src/web/archiving-settings.jsp
+++ b/src/web/archiving-settings.jsp
@@ -12,9 +12,10 @@
 <%@ page import="java.util.Map" %>
 <%@ page import="com.reucon.openfire.plugin.archive.impl.MucIndexer" %>
 <%@ page import="org.jivesoftware.openfire.plugin.service.LogAPI" %>
-<%@ page import="org.jivesoftware.util.*" %>
 <%@ page import="org.jivesoftware.openfire.http.HttpBindManager" %>
 <%@ page import="com.reucon.openfire.plugin.archive.impl.MessageIndexer" %>
+<%@ page import="org.jivesoftware.openfire.archive.MonitoringConstants" %>
+<%@ page import="org.jivesoftware.openfire.cluster.ClusterManager" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -310,11 +311,22 @@
 
 <div class="success" id="rebuild" style="display: <%=rebuildIndex?"block":"none"%>">
     <fmt:message key="archive.settings.rebuild.success"/>
-</div><br/>
+    <br/>
+</div>
 
 <% if (errors.size() > 0) { %>
 <div class="error">
     <%= errorMessage%>
+</div>
+<br/>
+<% } %>
+
+<% if (!ClusterManager.findRemotePluginsWithDifferentVersion(MonitoringConstants.PLUGIN_NAME).isEmpty()) { %>
+<div class="warning">
+    <fmt:message key="warning.clustering.versions">
+        <fmt:param value="<a href='/system-clustering.jsp'>" />
+        <fmt:param value="</a>" />
+    </fmt:message>
 </div>
 <br/>
 <% } %>

--- a/src/web/conversations.jsp
+++ b/src/web/conversations.jsp
@@ -10,6 +10,8 @@
 <%@ page import="org.jivesoftware.openfire.user.UserManager"%>
 <%@ page import="java.net.URLEncoder" %>
 <%@ page import="org.jivesoftware.util.StringUtils" %>
+<%@ page import="org.jivesoftware.openfire.archive.MonitoringConstants" %>
+<%@ page import="org.jivesoftware.openfire.cluster.ClusterManager" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -138,6 +140,16 @@ function updateConversations(data) {
 
 //# sourceURL=conversations.jsp
 </script>
+
+<% if (!ClusterManager.findRemotePluginsWithDifferentVersion(MonitoringConstants.PLUGIN_NAME).isEmpty()) { %>
+<div class="warning">
+    <fmt:message key="warning.clustering.versions">
+        <fmt:param value="<a href='/system-clustering.jsp'>" />
+        <fmt:param value="</a>" />
+    </fmt:message>
+</div>
+<br/>
+<% } %>
 
 <!-- <a href="#" onclick="conversationUpdater(); return false;">click me</a> -->
 <p>

--- a/src/web/stats-dashboard.jsp
+++ b/src/web/stats-dashboard.jsp
@@ -16,6 +16,8 @@
 <%@ page import="java.util.*"%>
 <%@ page import="org.jivesoftware.openfire.XMPPServer" %>
 <%@ page import="org.jivesoftware.openfire.plugin.MonitoringPlugin" %>
+<%@ page import="org.jivesoftware.openfire.cluster.ClusterManager" %>
+<%@ page import="org.jivesoftware.openfire.archive.MonitoringConstants" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
@@ -380,6 +382,17 @@ function createCookie(name,value,days) {
 </script>
 
 <div id="instructions">
+
+    <% if (!ClusterManager.findRemotePluginsWithDifferentVersion(MonitoringConstants.PLUGIN_NAME).isEmpty()) { %>
+    <div class="warning">
+        <fmt:message key="warning.clustering.versions">
+            <fmt:param value="<a href='/system-clustering.jsp'>" />
+            <fmt:param value="</a>" />
+        </fmt:message>
+    </div>
+    <br/>
+    <% } %>
+
     <table width="756" border="0">
     <tr>
         <td width="426">

--- a/src/web/stats-reporter.jsp
+++ b/src/web/stats-reporter.jsp
@@ -11,6 +11,8 @@
 <%@ page import="java.util.List"%>
 <%@ page import="org.jivesoftware.openfire.plugin.MonitoringPlugin" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer" %>
+<%@ page import="org.jivesoftware.openfire.cluster.ClusterManager" %>
+<%@ page import="org.jivesoftware.openfire.archive.MonitoringConstants" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
@@ -280,6 +282,16 @@
 </head>
 
 <body>
+
+<% if (!ClusterManager.findRemotePluginsWithDifferentVersion(MonitoringConstants.PLUGIN_NAME).isEmpty()) { %>
+<div class="warning">
+    <fmt:message key="warning.clustering.versions">
+        <fmt:param value="<a href='/system-clustering.jsp'>" />
+        <fmt:param value="</a>" />
+    </fmt:message>
+</div>
+<br/>
+<% } %>
 
 <table cellpadding="0" cellspacing="0" border="0" width="753">
 <tr>


### PR DESCRIPTION
The plugin cannot function properly when not all cluster nodes have the same version of the plugin installed.

The changes in this PR:
- Will show a warning on all plugin-provided admin console pages when it's detected that not every cluster member has the same version of the plugin installed
- Guards against failure to render the plugin-provided admin console pages. Note that no effort is made to ensure that proper data is displayed on those pages: when not all cluster nodes have the same plugin, that's impossible to guarantee.

The warning looks something like this. The screenshot also shows an impossible conversations count (that reflect data inconsistency).
![image](https://user-images.githubusercontent.com/4253898/147254473-6aa0ab6a-470f-40c2-902a-435ac8220039.png)
