### PR TITLE
fixes #235: Don't use deprecated Openfire methods

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -46,6 +46,7 @@ Monitoring Plugin Changelog
 
 <p><b>2.4.0</b> -- (tbd)</p>
 <ul>
+    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/235'>Issue #235</a>] - Plugin compatible with Openfire 4.8.0</li>
 </ul>
 
 <p><b>2.3.1</b> -- September 28, 2022</p>

--- a/src/java/com/reucon/openfire/plugin/archive/impl/PaginatedMessageLuceneQuery.java
+++ b/src/java/com/reucon/openfire/plugin/archive/impl/PaginatedMessageLuceneQuery.java
@@ -43,7 +43,7 @@ public class PaginatedMessageLuceneQuery
 
     protected IndexSearcher getSearcher() throws IOException
     {
-        final MonitoringPlugin plugin = (MonitoringPlugin) XMPPServer.getInstance().getPluginManager().getPlugin(MonitoringConstants.NAME);
+        final MonitoringPlugin plugin = (MonitoringPlugin) XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.NAME).get();
         final MessageIndexer archiveIndexer = plugin.getMessageIndexer();
         final IndexSearcher searcher = archiveIndexer.getSearcher();
         return searcher;

--- a/src/java/com/reucon/openfire/plugin/archive/impl/PaginatedMessageLuceneQuery.java
+++ b/src/java/com/reucon/openfire/plugin/archive/impl/PaginatedMessageLuceneQuery.java
@@ -43,7 +43,7 @@ public class PaginatedMessageLuceneQuery
 
     protected IndexSearcher getSearcher() throws IOException
     {
-        final MonitoringPlugin plugin = (MonitoringPlugin) XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.NAME).get();
+        final MonitoringPlugin plugin = (MonitoringPlugin) XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.PLUGIN_NAME).get();
         final MessageIndexer archiveIndexer = plugin.getMessageIndexer();
         final IndexSearcher searcher = archiveIndexer.getSearcher();
         return searcher;

--- a/src/java/com/reucon/openfire/plugin/archive/impl/PaginatedMucMessageLuceneQuery.java
+++ b/src/java/com/reucon/openfire/plugin/archive/impl/PaginatedMucMessageLuceneQuery.java
@@ -46,7 +46,7 @@ public class PaginatedMucMessageLuceneQuery
 
     protected IndexSearcher getSearcher() throws IOException
     {
-        final MonitoringPlugin plugin = (MonitoringPlugin) XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.NAME).get();
+        final MonitoringPlugin plugin = (MonitoringPlugin) XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.PLUGIN_NAME).get();
         final MessageIndexer archiveIndexer = plugin.getMessageIndexer();
         final IndexSearcher searcher = archiveIndexer.getSearcher();
         return searcher;

--- a/src/java/com/reucon/openfire/plugin/archive/impl/PaginatedMucMessageLuceneQuery.java
+++ b/src/java/com/reucon/openfire/plugin/archive/impl/PaginatedMucMessageLuceneQuery.java
@@ -46,7 +46,7 @@ public class PaginatedMucMessageLuceneQuery
 
     protected IndexSearcher getSearcher() throws IOException
     {
-        final MonitoringPlugin plugin = (MonitoringPlugin) XMPPServer.getInstance().getPluginManager().getPlugin(MonitoringConstants.NAME);
+        final MonitoringPlugin plugin = (MonitoringPlugin) XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.NAME).get();
         final MessageIndexer archiveIndexer = plugin.getMessageIndexer();
         final IndexSearcher searcher = archiveIndexer.getSearcher();
         return searcher;

--- a/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
+++ b/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
@@ -276,7 +276,7 @@ public class ConversationManager implements ComponentEventListener{
                         Date maxAgeDate = new Date(now.getTime() - maxAge.toMillis());
                         ArchiveSearch search = new ArchiveSearch();
                         search.setDateRangeMax(maxAgeDate);
-                        MonitoringPlugin plugin = (MonitoringPlugin) XMPPServer.getInstance().getPluginManager().getPlugin(MonitoringConstants.NAME);
+                        MonitoringPlugin plugin = (MonitoringPlugin) XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.NAME).get();
                         ArchiveSearcher archiveSearcher = plugin.getArchiveSearcher();
                         Collection<Conversation> conversations = archiveSearcher.search(search);
                         int conversationDeleted = 0;

--- a/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
+++ b/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
@@ -276,7 +276,7 @@ public class ConversationManager implements ComponentEventListener{
                         Date maxAgeDate = new Date(now.getTime() - maxAge.toMillis());
                         ArchiveSearch search = new ArchiveSearch();
                         search.setDateRangeMax(maxAgeDate);
-                        MonitoringPlugin plugin = (MonitoringPlugin) XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.NAME).get();
+                        MonitoringPlugin plugin = (MonitoringPlugin) XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.PLUGIN_NAME).get();
                         ArchiveSearcher archiveSearcher = plugin.getArchiveSearcher();
                         Collection<Conversation> conversations = archiveSearcher.search(search);
                         int conversationDeleted = 0;

--- a/src/java/org/jivesoftware/openfire/archive/ConversationPDFServlet.java
+++ b/src/java/org/jivesoftware/openfire/archive/ConversationPDFServlet.java
@@ -47,7 +47,7 @@ public class ConversationPDFServlet extends HttpServlet {
             return;
         }
 
-        MonitoringPlugin plugin = (MonitoringPlugin)XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.NAME).get();
+        MonitoringPlugin plugin = (MonitoringPlugin)XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.PLUGIN_NAME).get();
         ConversationManager conversationManager = plugin.getConversationManager();
         Conversation conversation;
         if (conversationID > -1) {

--- a/src/java/org/jivesoftware/openfire/archive/ConversationPDFServlet.java
+++ b/src/java/org/jivesoftware/openfire/archive/ConversationPDFServlet.java
@@ -47,8 +47,7 @@ public class ConversationPDFServlet extends HttpServlet {
             return;
         }
 
-        MonitoringPlugin plugin = (MonitoringPlugin)XMPPServer.getInstance().getPluginManager().getPlugin(
-                MonitoringConstants.NAME);
+        MonitoringPlugin plugin = (MonitoringPlugin)XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.NAME).get();
         ConversationManager conversationManager = plugin.getConversationManager();
         Conversation conversation;
         if (conversationID > -1) {

--- a/src/java/org/jivesoftware/openfire/archive/ConversationUtils.java
+++ b/src/java/org/jivesoftware/openfire/archive/ConversationUtils.java
@@ -74,8 +74,7 @@ public class ConversationUtils {
     public int getBuildProgress() {
         // Get handle on the Monitoring plugin
         MonitoringPlugin plugin =
-            (MonitoringPlugin)XMPPServer.getInstance().getPluginManager().getPlugin(
-                    MonitoringConstants.NAME);
+            (MonitoringPlugin)XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.NAME).get();
 
         ArchiveIndexer archiveIndexer = plugin.getArchiveIndexer();
 
@@ -98,8 +97,7 @@ public class ConversationUtils {
 
         // Get handle on the Monitoring plugin
         MonitoringPlugin plugin =
-            (MonitoringPlugin)XMPPServer.getInstance().getPluginManager().getPlugin(
-                    MonitoringConstants.NAME);
+            (MonitoringPlugin)XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.NAME).get();
 
         ConversationManager conversationmanager = plugin.getConversationManager();
 
@@ -123,7 +121,7 @@ public class ConversationUtils {
     public Map<String, ConversationInfo> getConversations(boolean formatParticipants) {
         Map<String, ConversationInfo> cons = new HashMap<String, ConversationInfo>();
         MonitoringPlugin plugin = (MonitoringPlugin)XMPPServer.getInstance().getPluginManager()
-            .getPlugin(MonitoringConstants.NAME);
+            .getPluginByName(MonitoringConstants.NAME).get();
         ConversationManager conversationManager = plugin.getConversationManager();
         Collection<Conversation> conversations = conversationManager.getConversations();
         List<Conversation> lConversations =

--- a/src/java/org/jivesoftware/openfire/archive/ConversationUtils.java
+++ b/src/java/org/jivesoftware/openfire/archive/ConversationUtils.java
@@ -74,7 +74,7 @@ public class ConversationUtils {
     public int getBuildProgress() {
         // Get handle on the Monitoring plugin
         MonitoringPlugin plugin =
-            (MonitoringPlugin)XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.NAME).get();
+            (MonitoringPlugin)XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.PLUGIN_NAME).get();
 
         ArchiveIndexer archiveIndexer = plugin.getArchiveIndexer();
 
@@ -97,7 +97,7 @@ public class ConversationUtils {
 
         // Get handle on the Monitoring plugin
         MonitoringPlugin plugin =
-            (MonitoringPlugin)XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.NAME).get();
+            (MonitoringPlugin)XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.PLUGIN_NAME).get();
 
         ConversationManager conversationmanager = plugin.getConversationManager();
 

--- a/src/java/org/jivesoftware/openfire/reporting/graph/GraphServlet.java
+++ b/src/java/org/jivesoftware/openfire/reporting/graph/GraphServlet.java
@@ -74,7 +74,7 @@ public class GraphServlet extends HttpServlet {
     public void init() throws ServletException {
         // load dependencies
         MonitoringPlugin plugin =
-                (MonitoringPlugin) XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.NAME).get();
+                (MonitoringPlugin) XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.PLUGIN_NAME).get();
         this.graphEngine = plugin.getGraphEngine();
         this.statsViewer = plugin.getStatsViewer();
     }

--- a/src/java/org/jivesoftware/openfire/reporting/graph/GraphServlet.java
+++ b/src/java/org/jivesoftware/openfire/reporting/graph/GraphServlet.java
@@ -74,7 +74,7 @@ public class GraphServlet extends HttpServlet {
     public void init() throws ServletException {
         // load dependencies
         MonitoringPlugin plugin =
-                (MonitoringPlugin) XMPPServer.getInstance().getPluginManager().getPlugin(MonitoringConstants.NAME);
+                (MonitoringPlugin) XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.NAME).get();
         this.graphEngine = plugin.getGraphEngine();
         this.statsViewer = plugin.getStatsViewer();
     }

--- a/src/java/org/jivesoftware/openfire/reporting/stats/StatsAction.java
+++ b/src/java/org/jivesoftware/openfire/reporting/stats/StatsAction.java
@@ -87,7 +87,7 @@ public class StatsAction {
     }
 
     private Map getUpdatedStat(String statkey, long[] timePeriod) {
-        MonitoringPlugin plugin = (MonitoringPlugin)XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.NAME).get();
+        MonitoringPlugin plugin = (MonitoringPlugin)XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.PLUGIN_NAME).get();
         StatsViewer viewer = plugin.getStatsViewer();
         String[] lowHigh = getLowAndHigh(statkey, timePeriod);
         Map stat = new HashMap();
@@ -109,7 +109,7 @@ public class StatsAction {
     public List<Map<String, Long>> getNLatestConversations(int count, long mostRecentConversationID) {
         // TODO Fix plugin name 2 lines below and missing classes
         List<Map<String, Long>> cons = new ArrayList<Map<String, Long>>();
-        MonitoringPlugin plugin = (MonitoringPlugin)XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.NAME).get();
+        MonitoringPlugin plugin = (MonitoringPlugin)XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.PLUGIN_NAME).get();
         ConversationManager conversationManager = plugin.getConversationManager();
         Collection<Conversation> conversations = conversationManager.getConversations();
         List<Conversation> lConversations = Arrays.asList(conversations.toArray(new Conversation[conversations.size()]));
@@ -168,7 +168,7 @@ public class StatsAction {
      * @return low and high values for the given time period / number of datapoints
      */
     public static String[] getLowAndHigh(String key,  long[] timePeriod) {
-        MonitoringPlugin plugin = (MonitoringPlugin)XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.NAME).get();
+        MonitoringPlugin plugin = (MonitoringPlugin)XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.PLUGIN_NAME).get();
         StatsViewer viewer = plugin.getStatsViewer();
         Statistic.Type type = viewer.getStatistic(key)[0].getStatType();
         double[] lows = viewer.getMin(key, timePeriod[0], timePeriod[1], (int)timePeriod[2]);

--- a/src/java/org/jivesoftware/openfire/reporting/stats/StatsAction.java
+++ b/src/java/org/jivesoftware/openfire/reporting/stats/StatsAction.java
@@ -87,7 +87,7 @@ public class StatsAction {
     }
 
     private Map getUpdatedStat(String statkey, long[] timePeriod) {
-        MonitoringPlugin plugin = (MonitoringPlugin)XMPPServer.getInstance().getPluginManager().getPlugin(MonitoringConstants.NAME);
+        MonitoringPlugin plugin = (MonitoringPlugin)XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.NAME).get();
         StatsViewer viewer = plugin.getStatsViewer();
         String[] lowHigh = getLowAndHigh(statkey, timePeriod);
         Map stat = new HashMap();
@@ -109,7 +109,7 @@ public class StatsAction {
     public List<Map<String, Long>> getNLatestConversations(int count, long mostRecentConversationID) {
         // TODO Fix plugin name 2 lines below and missing classes
         List<Map<String, Long>> cons = new ArrayList<Map<String, Long>>();
-        MonitoringPlugin plugin = (MonitoringPlugin)XMPPServer.getInstance().getPluginManager().getPlugin(MonitoringConstants.NAME);
+        MonitoringPlugin plugin = (MonitoringPlugin)XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.NAME).get();
         ConversationManager conversationManager = plugin.getConversationManager();
         Collection<Conversation> conversations = conversationManager.getConversations();
         List<Conversation> lConversations = Arrays.asList(conversations.toArray(new Conversation[conversations.size()]));
@@ -168,7 +168,7 @@ public class StatsAction {
      * @return low and high values for the given time period / number of datapoints
      */
     public static String[] getLowAndHigh(String key,  long[] timePeriod) {
-        MonitoringPlugin plugin = (MonitoringPlugin)XMPPServer.getInstance().getPluginManager().getPlugin(MonitoringConstants.NAME);
+        MonitoringPlugin plugin = (MonitoringPlugin)XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.NAME).get();
         StatsViewer viewer = plugin.getStatsViewer();
         Statistic.Type type = viewer.getStatistic(key)[0].getStatType();
         double[] lows = viewer.getMin(key, timePeriod[0], timePeriod[1], (int)timePeriod[2]);

--- a/src/web/archive-conversation-participants.jsp
+++ b/src/web/archive-conversation-participants.jsp
@@ -26,7 +26,7 @@
     // Get handle on the Monitoring plugin
     XMPPServer server = XMPPServer.getInstance();
     UserManager userManager = server.getUserManager();
-    MonitoringPlugin plugin = (MonitoringPlugin) server.getPluginManager().getPlugin("monitoring");
+    MonitoringPlugin plugin = (MonitoringPlugin) server.getPluginManager().getPluginByName("monitoring").get();
 
     ConversationManager conversationmanager = plugin.getConversationManager();
     List<String[]> values = new ArrayList<String[]>();
@@ -186,14 +186,14 @@
             %>
             <tr>
                 
-                <td><%=StringUtils.escapeHTMLTags(nickname)%> <i>(<%= server.isLocal(participant) && userManager.isRegisteredUser(participant) ? "<a href='/user-properties.jsp?username=" + participant.getNode() + "'>" + participant.toBareJID() + "</a>" : participant.toBareJID() %>)</i></td>
+                <td><%=StringUtils.escapeHTMLTags(nickname)%> <i>(<%= server.isLocal(participant) && userManager.isRegisteredUser(participant, false) ? "<a href='/user-properties.jsp?username=" + participant.getNode() + "'>" + participant.toBareJID() + "</a>" : participant.toBareJID() %>)</i></td>
 
                 <% if (it.hasNext()) {
                     participation = it.next();
                     nickname = participation[0];
                     participant = new  JID(participation[1]);
                 %>
-                <td><%=StringUtils.escapeHTMLTags(nickname)%> <i>(<%= server.isLocal(participant) && userManager.isRegisteredUser(participant) ? "<a href='/user-properties.jsp?username=" + participant.getNode() + "'>" + participant.toBareJID() + "</a>" : participant.toBareJID() %>)</i></td>
+                <td><%=StringUtils.escapeHTMLTags(nickname)%> <i>(<%= server.isLocal(participant) && userManager.isRegisteredUser(participant, false) ? "<a href='/user-properties.jsp?username=" + participant.getNode() + "'>" + participant.toBareJID() + "</a>" : participant.toBareJID() %>)</i></td>
                 <% } else { %>
                 <td>&nbsp;</td>
                 <% } %>

--- a/src/web/archive-conversation-participants.jsp
+++ b/src/web/archive-conversation-participants.jsp
@@ -13,6 +13,7 @@
 <%@ page import="java.util.*" %>
 <%@ page import="org.slf4j.LoggerFactory" %>
 <%@ page import="org.slf4j.Logger" %>
+<%@ page import="org.jivesoftware.openfire.archive.MonitoringConstants" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -26,7 +27,7 @@
     // Get handle on the Monitoring plugin
     XMPPServer server = XMPPServer.getInstance();
     UserManager userManager = server.getUserManager();
-    MonitoringPlugin plugin = (MonitoringPlugin) server.getPluginManager().getPluginByName("monitoring").get();
+    MonitoringPlugin plugin = (MonitoringPlugin) server.getPluginManager().getPluginByName(MonitoringConstants.PLUGIN_NAME).get();
 
     ConversationManager conversationmanager = plugin.getConversationManager();
     List<String[]> values = new ArrayList<String[]>();

--- a/src/web/archive-search.jsp
+++ b/src/web/archive-search.jsp
@@ -20,8 +20,7 @@
     Logger logger = LoggerFactory.getLogger("archive-search-jsp");
 
     // Get handle on the Monitoring plugin
-    MonitoringPlugin plugin = (MonitoringPlugin) XMPPServer.getInstance().getPluginManager().getPluginByName(
-            "monitoring").get();
+    MonitoringPlugin plugin = (MonitoringPlugin) XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.PLUGIN_NAME).get();
     ArchiveSearcher archiveSearcher = plugin.getArchiveSearcher();
     ConversationManager conversationManager = plugin.getConversationManager();
 

--- a/src/web/archive-search.jsp
+++ b/src/web/archive-search.jsp
@@ -20,8 +20,8 @@
     Logger logger = LoggerFactory.getLogger("archive-search-jsp");
 
     // Get handle on the Monitoring plugin
-    MonitoringPlugin plugin = (MonitoringPlugin) XMPPServer.getInstance().getPluginManager().getPlugin(
-            "monitoring");
+    MonitoringPlugin plugin = (MonitoringPlugin) XMPPServer.getInstance().getPluginManager().getPluginByName(
+            "monitoring").get();
     ArchiveSearcher archiveSearcher = plugin.getArchiveSearcher();
     ConversationManager conversationManager = plugin.getConversationManager();
 

--- a/src/web/archiving-settings.jsp
+++ b/src/web/archiving-settings.jsp
@@ -23,7 +23,7 @@
 <% webManager.init(request, response, session, application, out ); %>
 <%
     // Get handle on the Monitoring plugin
-    MonitoringPlugin plugin = (MonitoringPlugin) XMPPServer.getInstance().getPluginManager().getPluginByName("monitoring").get();
+    MonitoringPlugin plugin = (MonitoringPlugin) XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.PLUGIN_NAME).get();
     ConversationManager conversationManager = plugin.getConversationManager();
     ArchiveIndexer archiveIndexer = plugin.getArchiveIndexer();
     MucIndexer mucIndexer = plugin.getMucIndexer();

--- a/src/web/archiving-settings.jsp
+++ b/src/web/archiving-settings.jsp
@@ -23,7 +23,7 @@
 <% webManager.init(request, response, session, application, out ); %>
 <%
     // Get handle on the Monitoring plugin
-    MonitoringPlugin plugin = (MonitoringPlugin) XMPPServer.getInstance().getPluginManager().getPlugin("monitoring");
+    MonitoringPlugin plugin = (MonitoringPlugin) XMPPServer.getInstance().getPluginManager().getPluginByName("monitoring").get();
     ConversationManager conversationManager = plugin.getConversationManager();
     ArchiveIndexer archiveIndexer = plugin.getArchiveIndexer();
     MucIndexer mucIndexer = plugin.getMucIndexer();
@@ -445,14 +445,14 @@
                 <p><fmt:message key="archive.settings.logs.description" /></p>
                 <p>
                 <% if ( HttpBindManager.getInstance().isHttpBindActive() ) {
-                    final String unsecuredAddress = "http://" + XMPPServer.getInstance().getServerInfo().getHostname() + ":" + HttpBindManager.getInstance().getHttpBindUnsecurePort() + "/" + MonitoringPlugin.CONTEXT_ROOT + "/";
+                    final String unsecuredAddress = "http://" + XMPPServer.getInstance().getServerInfo().getHostname() + ":" + HttpBindManager.HTTP_BIND_PORT.getValue() + "/" + MonitoringPlugin.CONTEXT_ROOT + "/";
                 %>
                 <fmt:message key="archive.settings.logs.link.unsecure">
                     <fmt:param value="<%=unsecuredAddress%>"/>
                 </fmt:message>
                 <% } %>
                 <% if ( HttpBindManager.getInstance().isHttpsBindActive() ) {
-                    final String securedAddress = "https://" + XMPPServer.getInstance().getServerInfo().getHostname() + ":" + HttpBindManager.getInstance().getHttpBindSecurePort() + "/" + MonitoringPlugin.CONTEXT_ROOT + "/";
+                    final String securedAddress = "https://" + XMPPServer.getInstance().getServerInfo().getHostname() + ":" + HttpBindManager.HTTP_BIND_SECURE_PORT.getValue() + "/" + MonitoringPlugin.CONTEXT_ROOT + "/";
                 %>
                 <fmt:message key="archive.settings.logs.link.secure">
                     <fmt:param value="<%=securedAddress%>"/>

--- a/src/web/conversation-viewer.jsp
+++ b/src/web/conversation-viewer.jsp
@@ -1,8 +1,5 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.plugin.MonitoringPlugin" %>
-<%@ page import="org.jivesoftware.openfire.archive.ArchivedMessage" %>
-<%@ page import="org.jivesoftware.openfire.archive.Conversation" %>
-<%@ page import="org.jivesoftware.openfire.archive.ConversationManager" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer" %>
 <%@ page import="org.xmpp.packet.JID" %>
 <%@ page import="java.util.HashMap" %>
@@ -10,7 +7,7 @@
 <%@ page import="org.jivesoftware.util.*"%><%@ page import="java.util.Collection"%>
 <%@ page import="org.slf4j.LoggerFactory" %>
 <%@ page import="org.slf4j.Logger" %>
-<%@ page import="org.jivesoftware.openfire.archive.ConversationDAO" %>
+<%@ page import="org.jivesoftware.openfire.archive.*" %>
 <%!
      Map<String, String> colorMap = new HashMap<String, String>();
 %>
@@ -18,8 +15,7 @@
     Logger logger = LoggerFactory.getLogger("conversation-viewer-jsp");
 
     // Get handle on the Monitoring plugin
-    MonitoringPlugin plugin = (MonitoringPlugin)XMPPServer.getInstance().getPluginManager().getPluginByName(
-        "monitoring").get();
+    MonitoringPlugin plugin = (MonitoringPlugin)XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.PLUGIN_NAME).get();
 
     ConversationManager conversationManager = plugin.getConversationManager();
 

--- a/src/web/conversation-viewer.jsp
+++ b/src/web/conversation-viewer.jsp
@@ -18,8 +18,8 @@
     Logger logger = LoggerFactory.getLogger("conversation-viewer-jsp");
 
     // Get handle on the Monitoring plugin
-    MonitoringPlugin plugin = (MonitoringPlugin)XMPPServer.getInstance().getPluginManager().getPlugin(
-        "monitoring");
+    MonitoringPlugin plugin = (MonitoringPlugin)XMPPServer.getInstance().getPluginManager().getPluginByName(
+        "monitoring").get();
 
     ConversationManager conversationManager = plugin.getConversationManager();
 

--- a/src/web/conversations.jsp
+++ b/src/web/conversations.jsp
@@ -18,8 +18,7 @@
 
 <%
     // Get handle on the Monitoring plugin
-    MonitoringPlugin plugin = (MonitoringPlugin)XMPPServer.getInstance().getPluginManager().getPluginByName(
-        "monitoring").get();
+    MonitoringPlugin plugin = (MonitoringPlugin)XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.PLUGIN_NAME).get();
     ConversationManager conversationManager = plugin.getConversationManager();
 
     XMPPServer server = XMPPServer.getInstance();

--- a/src/web/conversations.jsp
+++ b/src/web/conversations.jsp
@@ -18,7 +18,8 @@
 
 <%
     // Get handle on the Monitoring plugin
-    MonitoringPlugin plugin = (MonitoringPlugin)XMPPServer.getInstance().getPluginManager().getPlugin("monitoring");
+    MonitoringPlugin plugin = (MonitoringPlugin)XMPPServer.getInstance().getPluginManager().getPluginByName(
+        "monitoring").get();
     ConversationManager conversationManager = plugin.getConversationManager();
 
     XMPPServer server = XMPPServer.getInstance();
@@ -191,7 +192,7 @@ function updateConversations(data) {
         <td>
             <% if (conversation.getRoom() == null) { %>
                 <% for (JID jid : participants) { %>
-                    <% if (server.isLocal(jid) && userManager.isRegisteredUser(jid.getNode())) { %>
+                    <% if (server.isLocal(jid) && userManager.isRegisteredUser(jid, false)) { %>
                         <a title='User Link' href="/user-properties.jsp?username=<%= jid.getNode() %>"><%= StringUtils.escapeHTMLTags(jid.toBareJID()) %></a><br />
                     <% } else { %>
                         <%= StringUtils.escapeHTMLTags(jid.toBareJID()) %><br/>

--- a/src/web/stats-dashboard.jsp
+++ b/src/web/stats-dashboard.jsp
@@ -23,7 +23,7 @@
 
 <%
     String sessionKey = StatisticsModule.SESSIONS_KEY;
-    MonitoringPlugin plugin = (MonitoringPlugin) XMPPServer.getInstance().getPluginManager().getPluginByName("monitoring").get();
+    MonitoringPlugin plugin = (MonitoringPlugin) XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.PLUGIN_NAME).get();
     ConversationManager conversationManager = plugin.getConversationManager();
     StatsViewer viewer = plugin.getStatsViewer();
 

--- a/src/web/stats-dashboard.jsp
+++ b/src/web/stats-dashboard.jsp
@@ -23,7 +23,7 @@
 
 <%
     String sessionKey = StatisticsModule.SESSIONS_KEY;
-    MonitoringPlugin plugin = (MonitoringPlugin) XMPPServer.getInstance().getPluginManager().getPlugin("monitoring");
+    MonitoringPlugin plugin = (MonitoringPlugin) XMPPServer.getInstance().getPluginManager().getPluginByName("monitoring").get();
     ConversationManager conversationManager = plugin.getConversationManager();
     StatsViewer viewer = plugin.getStatsViewer();
 

--- a/src/web/stats-reporter.jsp
+++ b/src/web/stats-reporter.jsp
@@ -560,7 +560,7 @@
     public static final String COOKIE_TIMEPERIOD = "openfire-reporting-timeperiod";
     public StatsViewer getStatsViewer() {
         if (statsViewer == null) {
-            MonitoringPlugin plugin = (MonitoringPlugin) XMPPServer.getInstance().getPluginManager().getPluginByName("monitoring").get();
+            MonitoringPlugin plugin = (MonitoringPlugin) XMPPServer.getInstance().getPluginManager().getPluginByName(MonitoringConstants.PLUGIN_NAME).get();
             statsViewer = plugin.getStatsViewer();
         }
         return statsViewer;

--- a/src/web/stats-reporter.jsp
+++ b/src/web/stats-reporter.jsp
@@ -560,7 +560,7 @@
     public static final String COOKIE_TIMEPERIOD = "openfire-reporting-timeperiod";
     public StatsViewer getStatsViewer() {
         if (statsViewer == null) {
-            MonitoringPlugin plugin = (MonitoringPlugin) XMPPServer.getInstance().getPluginManager().getPlugin("monitoring");
+            MonitoringPlugin plugin = (MonitoringPlugin) XMPPServer.getInstance().getPluginManager().getPluginByName("monitoring").get();
             statsViewer = plugin.getStatsViewer();
         }
         return statsViewer;


### PR DESCRIPTION
Replace deprecated methods with the modern equivalents