### PR TITLE
fixes #238: Release references provided by unloaded plugins

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -48,6 +48,7 @@ Monitoring Plugin Changelog
 <ul>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/232'>Issue #232</a>] - Fix SQL issue when retrieving archived messages from MSSQL</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/235'>Issue #235</a>] - Plugin compatible with Openfire 4.8.0</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/238'>Issue #238</a>] - Ensure that Statistics provided by unloaded plugins are no longer referenced.</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/240'>Issue #240</a>] - Stop using javascript libraries that are removed from Openfire 4.8</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/242'>Issue #242</a>] - Fix 'Unable to save XML properties' error</li>
 </ul>

--- a/src/java/org/jivesoftware/openfire/reporting/stats/StatsEngine.java
+++ b/src/java/org/jivesoftware/openfire/reporting/stats/StatsEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008 Jive Software. All rights reserved.
+ * Copyright (C) 2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,6 +96,11 @@ public class StatsEngine {
     public void stop() {
         // Clean-up sampling task
         samplingTask.cancel();
+    }
+
+    public void purgeDefinitions() {
+        definitionMap.clear();
+        multiMap.clear();
     }
 
     private void checkDatabase(StatDefinition[] def) throws RrdException, IOException {


### PR DESCRIPTION
When another plugin provides a Statistic instance, that instance should be released when the provider unloads. Failing to do so will prevent that plugin's classloader from being destroyed. This can cause all kinds of unexpected side-effects.

This commit removes references to _all_ Statistic instances whenever _any_ plugin unloads. That's a buckshot, but the effects should be limited to missing stats around the time that a plugin gets unloaded/reloaded - which is expected to be very rare.