### PR TITLE
fixes #357: No longer show NPE on admin console after user session expired

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -51,6 +51,7 @@ Monitoring Plugin Changelog
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/398'>Issue #398</a>] - Fixes: Missing translation for system property</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/392'>Issue #392</a>] - Fixes: Compatibility issue with Openfire 5.0.0</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/363'>Issue #363</a>] - Fixes SQL Server error: An expression of non-boolean type specified in a context where a condition is expected, near 'RowNum'</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/357'>Issue #357</a>] - Fixes: Error on admin console after user session expired.</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/354'>Issue #354</a>] - Allow full-text search / indexing to be disabled</li>
 </ul>
 

--- a/src/java/org/jivesoftware/openfire/plugin/MonitoringPlugin.java
+++ b/src/java/org/jivesoftware/openfire/plugin/MonitoringPlugin.java
@@ -64,7 +64,7 @@ public class MonitoringPlugin implements Plugin, PluginListener
     /**
      * The context root of the URL under which the public web endpoints are exposed.
      */
-    public static final String CONTEXT_ROOT = "monitoring";
+    public static final String CONTEXT_ROOT = "logs";
 
     private static final SystemProperty<Boolean> MOCK_VIEWER_ENABLED = SystemProperty.Builder.ofType( Boolean.class )
        .setKey("stats.mock.viewer" )


### PR DESCRIPTION
The NPE shown was an artifact of the page being processed without authentication in place. This should be prevented by the AuthCheckFilter.

Sadly, a naming collision prevents the AuthCheckFilter to operate on the Monitoring Service admin console pages.

This commit prevents the naming collision, by renaming the endpoint on which the public API for logs is exposed (from 'monitoring' to 'logs').

This is not an ideal solution, as it hides a deeper problem with regards to collision of web endpoints. Alas, I think this is the best that we can do without rewriting parts of Openfire (that may affect other plugins).