### PR TITLE
fixes #363: For SQL Server, move entire WHERE clause together

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -50,6 +50,7 @@ Monitoring Plugin Changelog
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/401'>Issue #401</a>] - Fixes: Update Jersey from 2.35 to 2.45</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/398'>Issue #398</a>] - Fixes: Missing translation for system property</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/392'>Issue #392</a>] - Fixes: Compatibility issue with Openfire 5.0.0</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/363'>Issue #363</a>] - Fixes SQL Server error: An expression of non-boolean type specified in a context where a condition is expected, near 'RowNum'</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/354'>Issue #354</a>] - Allow full-text search / indexing to be disabled</li>
 </ul>
 

--- a/src/java/com/reucon/openfire/plugin/archive/impl/JdbcPersistenceManager.java
+++ b/src/java/com/reucon/openfire/plugin/archive/impl/JdbcPersistenceManager.java
@@ -130,7 +130,7 @@ public class JdbcPersistenceManager implements PersistenceManager {
             firstIndex = firstIndex != null ? firstIndex : 0;
 
             if (DbConnectionManager.getDatabaseType() == DbConnectionManager.DatabaseType.sqlserver) {
-                limitSB.append(" BETWEEN ").append(firstIndex+1);
+                limitSB.append(" WHERE RowNum BETWEEN ").append(firstIndex+1);
                 limitSB.append(" AND ").append(firstIndex+max);
             }
             else {
@@ -146,7 +146,7 @@ public class JdbcPersistenceManager implements PersistenceManager {
         querySB.append(SELECT_CONVERSATIONS_GROUP_BY);
         if (DbConnectionManager.getDatabaseType() == DbConnectionManager.DatabaseType.sqlserver) {
             querySB.insert(0,"SELECT * FROM (SELECT *, ROW_NUMBER() OVER (ORDER BY "+CONVERSATION_ID+") AS RowNum FROM ( ");
-            querySB.append(") ofConversation ) t2 WHERE RowNum");
+            querySB.append(") ofConversation ) t2");
         }
         else {
             querySB.append(" ORDER BY ").append(CONVERSATION_ID);


### PR DESCRIPTION
Previously, it was possible, when querying an empty archive, to have a SQL statement that had the "WHERE RowNum" part of the clause, but not the "BETWEEN a AND b" part.

Fixes #363 - see issue for more details 