### PR TITLE
fixes #373: Separate stanza parsing from database loading

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -46,6 +46,7 @@ Monitoring Plugin Changelog
 
 <p><b>2.5.1</b> -- (tbd)</p>
 <ul>
+    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/373'>Issue #373</a>] - Separate stanza parsing from database loading</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/367'>Issue #367</a>] - Fixes: JRobin's repository uses invalid certificate</li>
 </ul>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
     <description>Monitors conversations and statistics of the server.</description>
     <author>Ignite Realtime</author>
     <version>${project.version}</version>
-    <date>2023-05-23</date>
+    <date>2024-02-16</date>
     <minServerVersion>4.7.0</minServerVersion>
     <minJavaVersion>1.8</minJavaVersion>
     <databaseKey>monitoring</databaseKey>


### PR DESCRIPTION
By not parsing database content immediately, this parsing can be done after the database connection has been released. This should reduce resource contention.