### PR TITLE
fixes #377: Remove erroneous index confirmation message

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -46,6 +46,7 @@ Monitoring Plugin Changelog
 
 <p><b>2.5.1</b> -- (tbd)</p>
 <ul>
+    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/377'>Issue #377</a>] - Fixes: Erroneous index confirmation message</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/367'>Issue #367</a>] - Fixes: JRobin's repository uses invalid certificate</li>
 </ul>
 

--- a/src/web/archiving-settings.jsp
+++ b/src/web/archiving-settings.jsp
@@ -306,10 +306,13 @@
     }
 %>
 
-<div class="success" id="rebuild" style="display: <%=rebuildIndex?"block":"none"%>">
+
+<% if (rebuildIndex) { %>
+<div class="success" id="rebuild">
     <fmt:message key="archive.settings.rebuild.success"/>
     <br/>
 </div>
+<% } %>
 
 <% if (errors.size() > 0) { %>
 <div class="error">


### PR DESCRIPTION
The archiving settings page on the admin console erroneously displays "Search Indexes are rebuilding." all the time - even when message archiving isn't even enabled.

I'm actually unsure why this change works. I assume there's javascript/CSS magic that causes the problem.