### PR TITLE
fixes #249: Prevent continuous rebuild of Lucene index being reported

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -47,6 +47,7 @@ Monitoring Plugin Changelog
 <p><b>2.5.1</b> -- (tbd)</p>
 <ul>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/367'>Issue #367</a>] - Fixes: JRobin's repository uses invalid certificate</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/249'>Issue #249</a>] - Fixes: Erroneous index rebuild progress indicator</li>
 </ul>
 
 <p><b>2.5.0</b> -- May 23, 2023</p>

--- a/src/web/archiving-settings.jsp
+++ b/src/web/archiving-settings.jsp
@@ -54,7 +54,7 @@
     function showBuildProgress(progress) {
         let rebuildElement = document.getElementById("rebuildElement");
         let rebuildProgress = document.getElementById('rebuildProgress');
-        if (progress != null && progress !== -1){
+        if (progress != null && progress !== '-1'){
             document.getElementById("rebuild").style.display="block";
             // Update progress item.
             rebuildElement.style.display = '';


### PR DESCRIPTION
The progress report that checks if Lucene indeces are rebuilt had a small error, causing the admin console to continuously display a message indicating that a rebuild was in progress.