### PR TITLE
Moving shared MAM Query representation into abstract class

### DIFF
--- a/src/java/com/reucon/openfire/plugin/archive/impl/AbstractPaginatedMamMucQuery.java
+++ b/src/java/com/reucon/openfire/plugin/archive/impl/AbstractPaginatedMamMucQuery.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2024 Ignite Realtime Foundation. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.reucon.openfire.plugin.archive.impl;
+
+import org.jivesoftware.openfire.muc.MUCRoom;
+import org.xmpp.packet.JID;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Date;
+
+/**
+ * Representation of a MAM query that is querying a multi-user chat-based archive.
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ */
+public abstract class AbstractPaginatedMamMucQuery extends AbstractPaginatedMamQuery
+{
+    /**
+     * The MUC room instance that owns the message archive.
+     */
+    @Nonnull
+    protected final MUCRoom room;
+
+    /**
+     * To be able to return not only the public messages exchanged in the room, but also the private messages that are
+     * relevant for the user that performs this query, an additional JID is provided as the 'messageOwner' argument.
+     * This identifies the user for which to retrieve the (private) messages.
+     */
+    @Nonnull
+    protected final JID messageOwner;
+
+    /**
+     * Creates a query for messages from a message archive.
+     * <p>
+     * To be able to return not only the public messages exchanged in the room, but also the private messages that are
+     * relevant for the user that performs this query, an additional JID is provided as the 'messageOwner' argument.
+     * This identifies the user for which to retrieve the (private) messages.
+     *
+     * @param startDate Start (inclusive) of period for which to return messages. EPOCH will be used if no value is provided.
+     * @param endDate End (inclusive) of period for which to return messages. 'now' will be used if no value is provided.
+     * @param room The multi-user chat room that is the message archive owner.
+     * @param messageOwner The entity for which to return messages (typically the JID of the entity making the request).
+     * @param with An optional conversation partner
+     */
+    public AbstractPaginatedMamMucQuery(@Nullable final Date startDate, @Nullable final Date endDate, @Nonnull final MUCRoom room, @Nonnull final JID messageOwner, @Nullable final JID with)
+    {
+        super(startDate, endDate, room.getJID(), with);
+        this.messageOwner = messageOwner;
+        this.room = room;
+    }
+
+    /**
+     * Creates a query for messages from a message archive.
+     * <p>
+     * To be able to return not only the public messages exchanged in the room, but also the private messages that are
+     * relevant for the user that performs this query, an additional JID is provided as the 'messageOwner' argument.
+     * This identifies the user for which to retrieve the (private) messages.
+     *
+     * @param startDate Start (inclusive) of period for which to return messages. EPOCH will be used if no value is provided.
+     * @param endDate End (inclusive) of period for which to return messages. 'now' will be used if no value is provided.
+     * @param room The multi-user chat room that is the message archive owner.
+     * @param messageOwner The entity for which to return messages (typically the JID of the entity making the request).
+     * @param with An optional conversation partner
+     * @param query A search string to be used for text-based search.
+     */
+    public AbstractPaginatedMamMucQuery(@Nullable final Date startDate, @Nullable final Date endDate, @Nonnull final MUCRoom room, @Nonnull final JID messageOwner, @Nullable final JID with, @Nonnull final String query)
+    {
+        super(startDate, endDate, room.getJID(), with, query);
+        this.messageOwner = messageOwner;
+        this.room = room;
+    }
+
+    @Nonnull
+    public MUCRoom getRoom()
+    {
+        return room;
+    }
+
+    @Nonnull
+    public JID getMessageOwner()
+    {
+        return messageOwner;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "AbstractPaginatedMamMucQuery{" +
+            "messageOwner=" + messageOwner +
+            ", startDate=" + startDate +
+            ", endDate=" + endDate +
+            ", archiveOwner=" + archiveOwner +
+            ", with=" + with +
+            ", query='" + query + '\'' +
+            '}';
+    }
+}

--- a/src/java/com/reucon/openfire/plugin/archive/impl/AbstractPaginatedMamQuery.java
+++ b/src/java/com/reucon/openfire/plugin/archive/impl/AbstractPaginatedMamQuery.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2024 Ignite Realtime Foundation. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.reucon.openfire.plugin.archive.impl;
+
+import com.reucon.openfire.plugin.archive.model.ArchivedMessage;
+import org.xmpp.packet.JID;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Representation of a MAM query.
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ */
+public abstract class AbstractPaginatedMamQuery
+{
+    /**
+     * Start (inclusive) of period for which to return messages.
+     */
+    @Nonnull
+    protected final Date startDate;
+
+    /**
+     * End (inclusive) of period for which to return messages.
+     */
+    @Nonnull
+    protected final Date endDate;
+
+    /**
+     * The message archive owner.
+     */
+    @Nonnull
+    protected final JID archiveOwner;
+
+    /**
+     * An optional conversation partner.
+     */
+    @Nullable
+    protected final JID with;
+
+    /**
+     * A search filter to be used for text-based search.
+     */
+    @Nullable
+    protected final String query;
+
+    /**
+     * Creates a query for messages from a message archive.
+     *
+     * @param startDate Start (inclusive) of period for which to return messages. EPOCH will be used if no value is provided.
+     * @param endDate End (inclusive) of period for which to return messages. 'now' will be used if no value is provided.
+     * @param archiveOwner The message archive owner.
+     * @param with An optional conversation partner
+     */
+    public AbstractPaginatedMamQuery(@Nullable final Date startDate, @Nullable final Date endDate, @Nonnull final JID archiveOwner, @Nullable final JID with)
+    {
+        this.startDate = startDate == null ? new Date( 0L ) : startDate ;
+        this.endDate = endDate == null ? new Date() : endDate;
+        this.archiveOwner = archiveOwner;
+        this.with = with;
+        this.query = null;
+    }
+
+    /**
+     * Creates a query for messages from a message archive.
+     *
+     * @param startDate Start (inclusive) of period for which to return messages. EPOCH will be used if no value is provided.
+     * @param endDate End (inclusive) of period for which to return messages. 'now' will be used if no value is provided.
+     * @param archiveOwner The message archive owner.
+     * @param with An optional conversation partner
+     * @param query A search string to be used for text-based search.
+     */
+    public AbstractPaginatedMamQuery(@Nullable final Date startDate, @Nullable final Date endDate, @Nonnull final JID archiveOwner, @Nullable final JID with, @Nonnull final String query)
+    {
+        this.startDate = startDate == null ? new Date( 0L ) : startDate ;
+        this.endDate = endDate == null ? new Date() : endDate;
+        this.archiveOwner = archiveOwner;
+        this.with = with;
+        this.query = query;
+    }
+
+    /**
+     * Get a page of a potentially larger list of archived messages that are the result of this query.
+     *
+     * @param after an optional message identifier that acts as a starting point (exclusive) of the messages to be returned.
+     * @param before an optional message identifier that acts as an end point (exclusive) of the messages to be returned.
+     * @param maxResults The maximum number of archived messages to return
+     * @param isPagingBackwards true if the order of the messages is from new to old, otherwise false.
+     * @return A list of archived messages
+     * @throws DataRetrievalException On any problem that occurs while retrieving the page of archived messages.
+     */
+    abstract protected List<ArchivedMessage> getPage(@Nullable final Long after, @Nullable final Long before, final int maxResults, final boolean isPagingBackwards) throws DataRetrievalException;
+
+    /**
+     * Returns the amount of messages that are in the entire, unlimited/unpaged, result set.
+     * <p>
+     * The returned number is allowed to be an approximation.
+     *
+     * @return A message count, or -1 if unavailable.
+     */
+    abstract protected int getTotalCount();
+
+    @Nonnull
+    public Date getStartDate()
+    {
+        return startDate;
+    }
+
+    @Nonnull
+    public Date getEndDate()
+    {
+        return endDate;
+    }
+
+    @Nonnull
+    public JID getArchiveOwner()
+    {
+        return archiveOwner;
+    }
+
+    @Nullable
+    public JID getWith()
+    {
+        return with;
+    }
+
+    @Nullable
+    public String getQuery() {
+        return query;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "AbstractPaginatedMamQuery{" +
+            "startDate=" + startDate +
+            ", endDate=" + endDate +
+            ", archiveOwner=" + archiveOwner +
+            ", with=" + with +
+            ", query='" + query + '\'' +
+            '}';
+    }
+}

--- a/src/java/com/reucon/openfire/plugin/archive/impl/MucMamPersistenceManager.java
+++ b/src/java/com/reucon/openfire/plugin/archive/impl/MucMamPersistenceManager.java
@@ -116,7 +116,7 @@ public class MucMamPersistenceManager implements PersistenceManager {
                 }
             } else {
                 Log.debug("Using Monitoring plugin tables");
-                final PaginatedMucMessageDatabaseQuery paginatedMessageDatabaseQuery = new PaginatedMucMessageDatabaseQuery(startDate, endDate, room.getJID(), messageOwner, with);
+                final PaginatedMucMessageDatabaseQuery paginatedMessageDatabaseQuery = new PaginatedMucMessageDatabaseQuery(startDate, endDate, room, messageOwner, with);
                 Log.debug("Request for message archive of room '{}' resulted in the following query data: {}", room.getJID(), paginatedMessageDatabaseQuery);
                 totalCount = paginatedMessageDatabaseQuery.getTotalCount();
                 if (totalCount == 0) {
@@ -174,7 +174,7 @@ public class MucMamPersistenceManager implements PersistenceManager {
                     final PaginatedMucMessageFromOpenfireDatabaseQuery paginatedMucMessageFromOpenfireDatabaseQuery = new PaginatedMucMessageFromOpenfireDatabaseQuery(startDate, endDate, room, with);
                     nextPage = paginatedMucMessageFromOpenfireDatabaseQuery.getPage(afterForNextPage, beforeForNextPage, 1, isPagingBackwards);
                 } else {
-                    final PaginatedMucMessageDatabaseQuery paginatedMessageDatabaseQuery = new PaginatedMucMessageDatabaseQuery(startDate, endDate, room.getJID(), messageOwner, with);
+                    final PaginatedMucMessageDatabaseQuery paginatedMessageDatabaseQuery = new PaginatedMucMessageDatabaseQuery(startDate, endDate, room, messageOwner, with);
                     nextPage = paginatedMessageDatabaseQuery.getPage(afterForNextPage, beforeForNextPage, 1, isPagingBackwards);
                 }
             }

--- a/src/java/com/reucon/openfire/plugin/archive/impl/PaginatedMucMessageDatabaseQuery.java
+++ b/src/java/com/reucon/openfire/plugin/archive/impl/PaginatedMucMessageDatabaseQuery.java
@@ -18,6 +18,7 @@ import com.reucon.openfire.plugin.archive.model.ArchivedMessage;
 import com.reucon.openfire.plugin.archive.xep0313.IQQueryHandler;
 import org.dom4j.DocumentException;
 import org.jivesoftware.database.DbConnectionManager;
+import org.jivesoftware.openfire.muc.MUCRoom;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmpp.packet.JID;
@@ -39,29 +40,14 @@ import java.util.List;
  *
  * @author Guus der Kinderen, guus.der.kinderen@gmail.com
  */
-public class PaginatedMucMessageDatabaseQuery
+public class PaginatedMucMessageDatabaseQuery extends AbstractPaginatedMamMucQuery
 {
-    private static final Logger Log = LoggerFactory.getLogger(PaginatedMucMessageDatabaseQuery.class );
-
-    @Nonnull
-    private final Date startDate;
-
-    @Nonnull
-    private final Date endDate;
-
-    @Nonnull
-    private final JID archiveOwner;
-
-    @Nonnull
-    private final JID messageOwner;
-
-    @Nullable
-    private final JID with;
+    private static final Logger Log = LoggerFactory.getLogger(PaginatedMucMessageDatabaseQuery.class);
 
     /**
-     * Creates a query for messages from a message archive.
+     * Creates a query for messages from a message archive of a multi-user chat room.
      *
-     * Two identifing JIDs are provided to this method: one is the JID of the room that's being queried (the 'archive
+     * Two identifying JIDs are provided to this method: one is the JID of the room that's being queried (the 'archive
      * owner'). To be able to return the private messages for a particular user from the room archive, an additional JID
      * is provided, that identifies the user for which to retrieve the messages.
      *
@@ -69,45 +55,11 @@ public class PaginatedMucMessageDatabaseQuery
      * @param endDate End (inclusive) of period for which to return messages. 'now' will be used if no value is provided.
      * @param archiveOwner The message archive owner (the JID of the chat room).
      * @param messageOwner The entity for which to return messages (typically the JID of the entity making the request).
-     * @param with An optional converstation partner (or message author, in case of MUC).
+     * @param with An optional conversation partner (or message author, in case of MUC).
      */
-    public PaginatedMucMessageDatabaseQuery(@Nullable final Date startDate, @Nullable final Date endDate, @Nonnull final JID archiveOwner, @Nonnull final JID messageOwner, @Nullable final JID with)
+    public PaginatedMucMessageDatabaseQuery(@Nullable final Date startDate, @Nullable final Date endDate, @Nonnull final MUCRoom archiveOwner, @Nonnull final JID messageOwner, @Nullable final JID with)
     {
-        this.startDate = startDate == null ? new Date( 0L ) : startDate ;
-        this.endDate = endDate == null ? new Date() : endDate;
-        this.archiveOwner = archiveOwner;
-        this.messageOwner = messageOwner;
-        this.with = with;
-    }
-
-    @Nonnull
-    public Date getStartDate()
-    {
-        return startDate;
-    }
-
-    @Nonnull
-    public Date getEndDate()
-    {
-        return endDate;
-    }
-
-    @Nonnull
-    public JID getArchiveOwner()
-    {
-        return archiveOwner;
-    }
-
-    @Nonnull
-    public JID getMessageOwner()
-    {
-        return messageOwner;
-    }
-
-    @Nullable
-    public JID getWith()
-    {
-        return with;
+        super(startDate, endDate, archiveOwner, messageOwner, with);
     }
 
     @Override
@@ -122,7 +74,8 @@ public class PaginatedMucMessageDatabaseQuery
             '}';
     }
 
-    protected List<ArchivedMessage> getPage( @Nullable final Long after, @Nullable final Long before, final int maxResults, final boolean isPagingBackwards ) throws DataRetrievalException {
+    @Override
+    protected List<ArchivedMessage> getPage(@Nullable final Long after, @Nullable final Long before, final int maxResults, final boolean isPagingBackwards) throws DataRetrievalException {
         Log.trace( "Getting page of archived messages. After: {}, Before: {}, Max results: {}, Paging backwards: {}", after, before, maxResults, isPagingBackwards );
 
         final List<ArchivedMessage> archivedMessages = new ArrayList<>();
@@ -196,6 +149,7 @@ public class PaginatedMucMessageDatabaseQuery
         return date == null ? null : date.getTime();
     }
 
+    @Override
     protected int getTotalCount()
     {
         Connection connection = null;

--- a/src/java/com/reucon/openfire/plugin/archive/impl/PaginatedMucMessageFromOpenfireDatabaseQuery.java
+++ b/src/java/com/reucon/openfire/plugin/archive/impl/PaginatedMucMessageFromOpenfireDatabaseQuery.java
@@ -24,6 +24,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmpp.packet.JID;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -33,48 +35,29 @@ import java.util.LinkedList;
 import java.util.List;
 
 /**
- * Encapsulates responsibility of creating a database query that retrieves a specific subset (page) of archived messages related to a MUC room.
+ * Encapsulates responsibility of creating a database query that retrieves a specific subset (page) of archived messages
+ * related to a MUC room.
  *
  * Note that this implementation primarily makes use of the database tables that are provided by Openfire (core), and
  * not of the database tables that are provided by the Monitoring plugin.
  *
  * @author Guus der Kinderen, guus.der.kinderen@gmail.com
  */
-public class PaginatedMucMessageFromOpenfireDatabaseQuery
+public class PaginatedMucMessageFromOpenfireDatabaseQuery extends AbstractPaginatedMamMucQuery
 {
-    private static final Logger Log = LoggerFactory.getLogger(PaginatedMucMessageFromOpenfireDatabaseQuery.class );
+    private static final Logger Log = LoggerFactory.getLogger(PaginatedMucMessageFromOpenfireDatabaseQuery.class);
 
-    private final Date startDate;
-    private final Date endDate;
-    private final MUCRoom room;
-    private final JID with;
-
-    public PaginatedMucMessageFromOpenfireDatabaseQuery(Date startDate, Date endDate, MUCRoom room, JID with )
+    /**
+     * Creates a query for messages from a message archive belonging to a multi-user chat room.
+     *
+     * @param startDate Start (inclusive) of period for which to return messages. EPOCH will be used if no value is provided.
+     * @param endDate End (inclusive) of period for which to return messages. 'now' will be used if no value is provided.
+     * @param room The message archive owner (the chat room).
+     * @param with An optional conversation partner (or message author, in case of MUC).
+     */
+    public PaginatedMucMessageFromOpenfireDatabaseQuery(@Nullable final Date startDate, @Nullable final Date endDate, @Nonnull final MUCRoom room, @Nullable final JID with)
     {
-        this.startDate = startDate == null ? new Date( 0L ) : startDate ;
-        this.endDate = endDate == null ? new Date() : endDate;
-        this.room = room;
-        this.with = with;
-    }
-
-    public Date getStartDate()
-    {
-        return startDate;
-    }
-
-    public Date getEndDate()
-    {
-        return endDate;
-    }
-
-    public MUCRoom getRoom()
-    {
-        return room;
-    }
-
-    public JID getWith()
-    {
-        return with;
+        super(startDate, endDate, room, null, with);
     }
 
     @Override
@@ -88,7 +71,8 @@ public class PaginatedMucMessageFromOpenfireDatabaseQuery
             '}';
     }
 
-    protected List<ArchivedMessage> getPage( final Long after, final Long before, final int maxResults, final boolean isPagingBackwards ) throws DataRetrievalException {
+    @Override
+    protected List<ArchivedMessage> getPage(final Long after, final Long before, final int maxResults, final boolean isPagingBackwards) throws DataRetrievalException {
         Log.trace( "Getting page of archived messages. After: {}, Before: {}, Max results: {}, Paging backwards: {}", after, before, maxResults, isPagingBackwards );
         final List<ArchivedMessage> msgs = new LinkedList<>();
 
@@ -152,7 +136,7 @@ public class PaginatedMucMessageFromOpenfireDatabaseQuery
         return msgs;
     }
 
-
+    @Override
     protected int getTotalCount()
     {
         Connection connection = null;


### PR DESCRIPTION
The Monitoring Service plugin's XEP-0313: Message Archive Management implementation contains at least six similar query implementations. The code that is duplicated between them is moved to abstract classes, that the original code now inherits from. This reduces code duplication and makes it easier to add new query types.