### PR TITLE
Fix compatibility issue with Openfire 4.9.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ "8", "11" ]
+        java: [ "11" ]
 
     steps:
       # Checkout Repo

--- a/changelog.html
+++ b/changelog.html
@@ -44,9 +44,11 @@
 Monitoring Plugin Changelog
 </h1>
 
-<p><b>2.5.1</b> -- (tbd)</p>
+<p><b>2.6.0</b> -- (tbd)</p>
 <ul>
-    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/377'>Issue #383</a>] - Fixes: Database query fails on Oracle</li>
+    <li>Requires Openfire 4.8.0</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/387'>Issue #387</a>] - Fixes: Compatibility issue with Openfire 4.9.0</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/383'>Issue #383</a>] - Fixes: Database query fails on Oracle</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/377'>Issue #377</a>] - Fixes: Erroneous index confirmation message</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/367'>Issue #367</a>] - Fixes: JRobin's repository uses invalid certificate</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/249'>Issue #249</a>] - Fixes: Erroneous index rebuild progress indicator</li>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,8 +6,8 @@
     <description>Monitors conversations and statistics of the server.</description>
     <author>Ignite Realtime</author>
     <version>${project.version}</version>
-    <date>2024-04-17</date>
-    <minServerVersion>4.7.0</minServerVersion>
+    <date>2024-08-23</date>
+    <minServerVersion>4.8.0</minServerVersion>
     <minJavaVersion>1.8</minJavaVersion>
     <databaseKey>monitoring</databaseKey>
     <databaseVersion>8</databaseVersion>

--- a/plugin.xml
+++ b/plugin.xml
@@ -8,7 +8,6 @@
     <version>${project.version}</version>
     <date>2024-08-23</date>
     <minServerVersion>4.8.0</minServerVersion>
-    <minJavaVersion>1.8</minJavaVersion>
     <databaseKey>monitoring</databaseKey>
     <databaseVersion>8</databaseVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.7.0</version>
+        <version>4.8.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>monitoring</artifactId>
-    <version>2.5.1-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
     <name>Monitoring Plugin</name>
     <description>Monitors conversations and statistics of the server.</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,9 +53,9 @@
             <version>${jersey.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.jrobin</groupId>
+            <groupId>com.purej</groupId>
             <artifactId>jrobin</artifactId>
-            <version>1.6.0</version>
+            <version>1.7.1</version>
         </dependency>
         <dependency>
             <groupId>jfree</groupId>
@@ -112,13 +112,6 @@
             <id>igniterealtime</id>
             <name>Ignite Realtime Repository</name>
             <url>https://igniterealtime.org/archiva/repository/maven/</url>
-        </repository>
-
-        <!-- For jrobin -->
-        <repository>
-            <id>opennms-repo</id>
-            <name>OpenNMS Release Repository</name>
-            <url>https://maven.mirrors.opennms.org/maven2/</url>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,12 @@
             <artifactId>jaxb-runtime</artifactId>
             <version>2.3.3</version>
         </dependency>
-
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/src/java/com/reucon/openfire/plugin/archive/impl/MessageIndexer.java
+++ b/src/java/com/reucon/openfire/plugin/archive/impl/MessageIndexer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2008 Jive Software, 2024 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.reucon.openfire.plugin.archive.impl;
 
 import org.apache.lucene.document.*;
@@ -17,6 +32,7 @@ import javax.annotation.Nullable;
 import javax.print.Doc;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -53,7 +69,7 @@ public class MessageIndexer extends LuceneIndexer
 
     public MessageIndexer( final TaskEngine taskEngine, final ConversationManager conversationManager )
     {
-        super(taskEngine, new File(JiveGlobals.getHomeDirectory() + File.separator + MonitoringConstants.NAME + File.separator + "msgsearch"), "MESSAGE", SCHEMA_VERSION);
+        super(taskEngine, JiveGlobals.getHomePath().resolve(Path.of(MonitoringConstants.NAME, "msgsearch")), "MESSAGE", SCHEMA_VERSION);
         this.conversationManager = conversationManager;
     }
 

--- a/src/java/com/reucon/openfire/plugin/archive/impl/MucIndexer.java
+++ b/src/java/com/reucon/openfire/plugin/archive/impl/MucIndexer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2008 Jive Software, 2024 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.reucon.openfire.plugin.archive.impl;
 
 import org.apache.lucene.document.*;
@@ -13,6 +28,7 @@ import org.xmpp.packet.JID;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -41,7 +57,7 @@ public class MucIndexer extends LuceneIndexer
 
     public MucIndexer( final TaskEngine taskEngine, final ConversationManager conversationManager )
     {
-        super(taskEngine, new File(JiveGlobals.getHomeDirectory() + File.separator + MonitoringConstants.NAME + File.separator + "mucsearch"), "MUCSEARCH", SCHEMA_VERSION);
+        super(taskEngine, JiveGlobals.getHomePath().resolve(Path.of(MonitoringConstants.NAME, "mucsearch")), "MUCSEARCH", SCHEMA_VERSION);
         this.conversationManager = conversationManager;
     }
 

--- a/src/java/org/jivesoftware/openfire/archive/ArchiveIndexer.java
+++ b/src/java/org/jivesoftware/openfire/archive/ArchiveIndexer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008 Jive Software. All rights reserved.
+ * Copyright (C) 2008 Jive Software, Ignite Realtime Foundation 2024. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.xmpp.packet.JID;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -67,7 +68,7 @@ public class ArchiveIndexer extends org.jivesoftware.openfire.index.LuceneIndexe
      * @param taskEngine a task engine instance.
      */
     public ArchiveIndexer(ConversationManager conversationManager, TaskEngine taskEngine) {
-        super(taskEngine, new File(JiveGlobals.getHomeDirectory() + File.separator + MonitoringConstants.NAME + File.separator + "search"), "CONVERSATION", SCHEMA_VERSION);
+        super(taskEngine, JiveGlobals.getHomePath().resolve(Path.of(MonitoringConstants.NAME, "search")), "CONVERSATION", SCHEMA_VERSION);
         this.conversationManager = conversationManager;
     }
 

--- a/src/java/org/jivesoftware/openfire/archive/ConversationEventsQueue.java
+++ b/src/java/org/jivesoftware/openfire/archive/ConversationEventsQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008 Jive Software. All rights reserved.
+ * Copyright (C) 2008 Jive Software, Ignite Realtime Foundation 2024. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.jivesoftware.openfire.archive;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -96,7 +97,7 @@ public class ConversationEventsQueue {
                 }
             }
         };
-        taskEngine.scheduleAtFixedRate(sendTask, JiveConstants.SECOND * 3, JiveConstants.SECOND * 3);
+        taskEngine.scheduleAtFixedRate(sendTask, Duration.ofSeconds(3), Duration.ofSeconds(3));
     }
 
     /**

--- a/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
+++ b/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008 Jive Software. All rights reserved.
+ * Copyright (C) 2008 Jive Software, Ignite Realtime Foundation 2024. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -255,7 +255,7 @@ public class ConversationManager implements ComponentEventListener{
                 }
             }
         };
-        taskEngine.scheduleAtFixedRate(cleanupTask, JiveConstants.MINUTE * 5, JiveConstants.MINUTE * 5);
+        taskEngine.scheduleAtFixedRate(cleanupTask, Duration.ofMinutes(5), Duration.ofMinutes(5));
 
         // Schedule a task to do conversation purging.
         maxAgeTask = new TimerTask() {
@@ -304,7 +304,7 @@ public class ConversationManager implements ComponentEventListener{
                 }
             }
         };
-        taskEngine.scheduleAtFixedRate(maxAgeTask, JiveConstants.MINUTE, JiveConstants.MINUTE);
+        taskEngine.scheduleAtFixedRate(maxAgeTask, Duration.ofMinutes(1), Duration.ofMinutes(1));
 
         // Register a statistic.
         Statistic conversationStat = new Statistic() {

--- a/src/java/org/jivesoftware/openfire/plugin/MonitoringPlugin.java
+++ b/src/java/org/jivesoftware/openfire/plugin/MonitoringPlugin.java
@@ -17,7 +17,6 @@
 package org.jivesoftware.openfire.plugin;
 
 import java.io.File;
-import java.io.FileFilter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -172,13 +171,6 @@ public class MonitoringPlugin implements Plugin, PluginListener
 
         xep0313Support2 = new Xep0313Support2(XMPPServer.getInstance());
         xep0313Support2.start();
-
-        // Check if we Enterprise is installed and stop loading this plugin if found
-        if (manager.getPluginByName("enterprise").isPresent()) {
-            // Do not load this plugin since Enterprise is still installed
-            System.out.println("Enterprise plugin found. Stopping Monitoring Plugin");
-            throw new IllegalStateException("This plugin cannot run next to the Enterprise plugin");
-        }
 
         // Make sure that the monitoring folder exists under the home directory
         final Path monitoringFolder = JiveGlobals.getHomePath().resolve(MonitoringConstants.NAME);

--- a/src/java/org/jivesoftware/openfire/reporting/stats/StatsEngine.java
+++ b/src/java/org/jivesoftware/openfire/reporting/stats/StatsEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2008 Jive Software, 2022-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@ package org.jivesoftware.openfire.reporting.stats;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -86,7 +88,7 @@ public class StatsEngine {
 
             // After 10 milliseconds begin sampling in 60 second intervals. Note: We need to start
             // asap so that the UI can access this info upon start up
-            taskEngine.scheduleAtFixedRate(samplingTask, 10, STAT_RESOULUTION * 1000L);
+            taskEngine.scheduleAtFixedRate(samplingTask, Duration.ofMillis(10), Duration.ofSeconds(STAT_RESOULUTION));
         }
         catch (RrdException e) {
             Log.error("Error initializing RrdbPool.", e);
@@ -104,10 +106,10 @@ public class StatsEngine {
     }
 
     private void checkDatabase(StatDefinition[] def) throws RrdException, IOException {
-        File directory = new File(getStatsDirectroy());
+        File directory = getStatsDirectory().toFile();
         if (directory.exists()) {
             // check if the rrd exists
-            File rrdFile = new File(getRrdFilePath(def[0].getDbPath()));
+            File rrdFile = getRrdFilePath(def[0].getDbPath()).toFile();
             if (rrdFile.exists() && rrdFile.canRead()) {
                 try {
                     // Import existing RRD file into the DB
@@ -163,8 +165,8 @@ public class StatsEngine {
      * @param datasourceName the name of the data source.
      * @return the path to the RRD file.
      */
-    private String getRrdFilePath(String datasourceName) {
-        return getStatsDirectroy() + datasourceName + ".rrd";
+    private Path getRrdFilePath(String datasourceName) {
+        return getStatsDirectory().resolve(datasourceName + ".rrd");
     }
 
     /**
@@ -172,9 +174,8 @@ public class StatsEngine {
      *
      * @return Returns the directory in which all of the stat databases will be stored.
      */
-    private String getStatsDirectroy() {
-        return JiveGlobals.getHomeDirectory() + File.separator + MonitoringConstants.NAME
-                + File.separator + "stats" + File.separator;
+    private Path getStatsDirectory() {
+        return JiveGlobals.getHomePath().resolve(Path.of(MonitoringConstants.NAME, "stats"));
     }
 
     private StatDefinition createDefintion(String key) {

--- a/src/java/org/jivesoftware/openfire/reporting/util/TaskEngine.java
+++ b/src/java/org/jivesoftware/openfire/reporting/util/TaskEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008 Jive Software. All rights reserved.
+ * Copyright (C) 2008 Jive Software, Ignite Realtime Foundation 2024. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@ import org.jivesoftware.util.NamedThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.*;
 
@@ -81,18 +83,18 @@ public class TaskEngine {
      * Schedules the specified task for execution after the specified delay.
      *
      * @param task  task to be scheduled.
-     * @param delay delay in milliseconds before task is to be executed.
+     * @param delay delay before task is to be executed.
      * @throws IllegalArgumentException if <tt>delay</tt> is negative, or
      *         <tt>delay + System.currentTimeMillis()</tt> is negative.
      * @throws IllegalStateException if task was already scheduled or
      *         cancelled, or timer was cancelled.
      */
-    public void schedule(TimerTask task, long delay) {
+    public void schedule(TimerTask task, Duration delay) {
         TimerTaskWrapper taskWrapper = new TimerTaskWrapper(task);
         synchronized (wrappedTasks) {
             wrappedTasks.put(task, taskWrapper);
         }
-        timer.schedule(taskWrapper, delay);
+        timer.schedule(taskWrapper, delay.toMillis());
     }
 
     /**
@@ -105,12 +107,12 @@ public class TaskEngine {
      * @throws IllegalStateException if task was already scheduled or
      *         cancelled, timer was cancelled, or timer thread terminated.
      */
-    public void schedule(TimerTask task, Date time) {
+    public void schedule(TimerTask task, Instant time) {
         TimerTaskWrapper taskWrapper = new TimerTaskWrapper(task);
         synchronized (wrappedTasks) {
             wrappedTasks.put(task, taskWrapper);
         }
-        timer.schedule(taskWrapper, time);
+        timer.schedule(taskWrapper, Date.from(time));
     }
 
     /**
@@ -136,19 +138,19 @@ public class TaskEngine {
      * is held down.
      *
      * @param task   task to be scheduled.
-     * @param delay  delay in milliseconds before task is to be executed.
-     * @param period time in milliseconds between successive task executions.
+     * @param delay  delay before task is to be executed.
+     * @param period time between successive task executions.
      * @throws IllegalArgumentException if <tt>delay</tt> is negative, or
      *         <tt>delay + System.currentTimeMillis()</tt> is negative.
      * @throws IllegalStateException if task was already scheduled or
      *         cancelled, timer was cancelled, or timer thread terminated.
      */
-    public void schedule(TimerTask task, long delay, long period) {
+    public void schedule(TimerTask task, Duration delay, Duration period) {
         TimerTaskWrapper taskWrapper = new TimerTaskWrapper(task);
         synchronized (wrappedTasks) {
             wrappedTasks.put(task, taskWrapper);
         }
-        timer.schedule(taskWrapper, delay, period);
+        timer.schedule(taskWrapper, delay.toMillis(), period.toMillis());
     }
 
     /**
@@ -175,17 +177,17 @@ public class TaskEngine {
      *
      * @param task   task to be scheduled.
      * @param firstTime First time at which task is to be executed.
-     * @param period time in milliseconds between successive task executions.
+     * @param period time between successive task executions.
      * @throws IllegalArgumentException if <tt>time.getTime()</tt> is negative.
      * @throws IllegalStateException if task was already scheduled or
      *         cancelled, timer was cancelled, or timer thread terminated.
      */
-    public void schedule(TimerTask task, Date firstTime, long period) {
+    public void schedule(TimerTask task, Instant firstTime, Duration period) {
         TimerTaskWrapper taskWrapper = new TimerTaskWrapper(task);
         synchronized (wrappedTasks) {
             wrappedTasks.put(task, taskWrapper);
         }
-        timer.schedule(taskWrapper, firstTime, period);
+        timer.schedule(taskWrapper, Date.from(firstTime), period.toMillis());
     }
 
     /**
@@ -212,19 +214,19 @@ public class TaskEngine {
      * with respect to one another.
      *
      * @param task   task to be scheduled.
-     * @param delay  delay in milliseconds before task is to be executed.
-     * @param period time in milliseconds between successive task executions.
+     * @param delay delay before task is to be executed.
+     * @param period time between successive task executions.
      * @throws IllegalArgumentException if <tt>delay</tt> is negative, or
      *         <tt>delay + System.currentTimeMillis()</tt> is negative.
      * @throws IllegalStateException if task was already scheduled or
      *         cancelled, timer was cancelled, or timer thread terminated.
      */
-    public void scheduleAtFixedRate(TimerTask task, long delay, long period) {
+    public void scheduleAtFixedRate(TimerTask task, Duration delay, Duration period) {
         TimerTaskWrapper taskWrapper = new TimerTaskWrapper(task);
         synchronized (wrappedTasks) {
             wrappedTasks.put(task, taskWrapper);
         }
-        timer.scheduleAtFixedRate(taskWrapper, delay, period);
+        timer.scheduleAtFixedRate(taskWrapper, delay.toMillis(), period.toMillis());
     }
 
     /**
@@ -252,17 +254,17 @@ public class TaskEngine {
      *
      * @param task   task to be scheduled.
      * @param firstTime First time at which task is to be executed.
-     * @param period time in milliseconds between successive task executions.
+     * @param period time between successive task executions.
      * @throws IllegalArgumentException if <tt>time.getTime()</tt> is negative.
      * @throws IllegalStateException if task was already scheduled or
      *         cancelled, timer was cancelled, or timer thread terminated.
      */
-    public void scheduleAtFixedRate(TimerTask task, Date firstTime, long period) {
+    public void scheduleAtFixedRate(TimerTask task, Instant firstTime, Duration period) {
         TimerTaskWrapper taskWrapper = new TimerTaskWrapper(task);
         synchronized (wrappedTasks) {
             wrappedTasks.put(task, taskWrapper);
         }
-        timer.scheduleAtFixedRate(taskWrapper, firstTime, period);
+        timer.scheduleAtFixedRate(taskWrapper, Date.from(firstTime), period.toMillis());
     }
 
     /**

--- a/src/web/archive-search.jsp
+++ b/src/web/archive-search.jsp
@@ -10,7 +10,6 @@
 <%@ page import="java.util.*" %>
 <%@ page import="org.slf4j.Logger" %>
 <%@ page import="org.slf4j.LoggerFactory" %>
-<%@ page import="com.reucon.openfire.plugin.archive.xep.AbstractXepSupport" %>
 <%@ page import="org.jivesoftware.openfire.archive.*" %>
 <%@ page import="org.jivesoftware.openfire.cluster.ClusterManager" %>
 
@@ -122,8 +121,13 @@
                 // occurs at 5:33 PM that day, it should be included in the results. In
                 // order to make this possible, we need to make the end date one millisecond
                 // before the next day starts.
-                date = new Date(date.getTime() + JiveConstants.DAY - 1);
-                search.setDateRangeMax(date);
+                final Calendar calendar = Calendar.getInstance();
+                calendar.setTime(date);
+                calendar.set(Calendar.HOUR_OF_DAY, 23);
+                calendar.set(Calendar.MINUTE, 59);
+                calendar.set(Calendar.SECOND, 59);
+                calendar.set(Calendar.MILLISECOND, 999);
+                search.setDateRangeMax(calendar.getTime());
             }
             catch (Exception e) {
                 // TODO: mark as an error in the JSP instead of logging..


### PR DESCRIPTION
Replaced Openfire API usage that was deprecated in Openfire 4.8.0 and removed in 4.9.0.

This plugin is now compatible with Openfire 4.9.0 and requires 4.8.0 or later. No longer compatible with versions older than 4.8.0.

fixes #387