### PR TITLE
Branch 2.6 will not be compatible with Openfire 4.10.0

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -46,6 +46,7 @@ Monitoring Plugin Changelog
 
 <p><b>2.6.1</b> -- (To be determined)</p>
 <ul>
+    <li>Explicitly denote that this version will not be compatible with Openfire 4.10.0 or later.</li>
 </ul>
 
 <p><b>2.6.0</b> -- September 12, 2024</p>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,8 +6,9 @@
     <description>Monitors conversations and statistics of the server.</description>
     <author>Ignite Realtime</author>
     <version>${project.version}</version>
-    <date>2024-09-12</date>
+    <date>2024-10-30</date>
     <minServerVersion>4.8.0</minServerVersion>
+    <priorToServerVersion>4.10.0</priorToServerVersion>
     <databaseKey>monitoring</databaseKey>
     <databaseVersion>8</databaseVersion>
 


### PR DESCRIPTION
This adds a `priorToServerVersion` definition (which should be removed in a future version).

This should help prevent people running into #392