### PR TITLE
fixes #230: Jackson-database security issue

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -53,6 +53,7 @@ Monitoring Plugin Changelog
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/363'>Issue #363</a>] - Fixes SQL Server error: An expression of non-boolean type specified in a context where a condition is expected, near 'RowNum'</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/357'>Issue #357</a>] - Fixes: Error on admin console after user session expired.</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/354'>Issue #354</a>] - Allow full-text search / indexing to be disabled</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/230'>Issue #230</a>] - Fixes: Jackson-databind security issue</li>
 </ul>
 
 <p><b>2.6.1</b> -- October 30, 2024</p>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,6 @@
     <description>Monitors conversations and statistics of the server.</description>
 
     <properties>
-        <jackson.version>2.12.1</jackson.version>
         <jersey.version>2.45</jersey.version>
     </properties>
 


### PR DESCRIPTION
By virtue of the upgrade of Jersey from 2.35 to 2.45 (in #401), the transient dependency of `jackson-database` got updated. This resolves the issue implicitly.

In this commit, a changelog entry is added, and an unused version identifier is removed.

This replaces PR #231