### PR TITLE
#369 and #370: Add support for the clear chat room history event

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -47,6 +47,7 @@ Monitoring Plugin Changelog
 <p><b>2.7.0</b> -- To be determined</p>
 <ul>
     <li>Requires Openfire 5.0.0</li>
+    <li>Note: Chat rooms can, in certain circumstances, be destroyed, and then be recreated using the same name. For data recorded by previous versions of this plugin, the plugin will associate all room history with the latest 'reincarnation' of a room. Starting with this version, new data will be associated to the correct 'incarnation' of the room.</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/401'>Issue #401</a>] - Fixes: Update Jersey from 2.35 to 2.45</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/398'>Issue #398</a>] - Fixes: Missing translation for system property</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/392'>Issue #392</a>] - Fixes: Compatibility issue with Openfire 5.0.0</li>

--- a/changelog.html
+++ b/changelog.html
@@ -51,6 +51,8 @@ Monitoring Plugin Changelog
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/401'>Issue #401</a>] - Fixes: Update Jersey from 2.35 to 2.45</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/398'>Issue #398</a>] - Fixes: Missing translation for system property</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/392'>Issue #392</a>] - Fixes: Compatibility issue with Openfire 5.0.0</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/370'>Issue #370</a>] - Add option to delete history on room deletion</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/369'>Issue #369</a>] - Add option to clear history for a given MUC</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/363'>Issue #363</a>] - Fixes SQL Server error: An expression of non-boolean type specified in a context where a condition is expected, near 'RowNum'</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/357'>Issue #357</a>] - Fixes: Error on admin console after user session expired.</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/354'>Issue #354</a>] - Allow full-text search / indexing to be disabled</li>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,10 +6,10 @@
     <description>Monitors conversations and statistics of the server.</description>
     <author>Ignite Realtime</author>
     <version>${project.version}</version>
-    <date>2024-11-22</date>
+    <date>2025-01-03</date>
     <minServerVersion>5.0.0</minServerVersion>
     <databaseKey>monitoring</databaseKey>
-    <databaseVersion>8</databaseVersion>
+    <databaseVersion>9</databaseVersion>
 
     <adminconsole>
         <tab id="tab-server">
@@ -33,7 +33,7 @@
                       url="conversations.jsp"
                       description="${admin.item.active-conversations.description}"/>
             </sidebar>
-
         </tab>
+
     </adminconsole>
 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>5.0.0-SNAPSHOT</version>
+        <version>5.0.0-alpha</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>monitoring</artifactId>

--- a/src/database/monitoring_db2.sql
+++ b/src/database/monitoring_db2.sql
@@ -1,8 +1,9 @@
 
-INSERT INTO ofVersion (name, version) VALUES ('monitoring', 8);
+INSERT INTO ofVersion (name, version) VALUES ('monitoring', 9);
 
 CREATE TABLE ofConversation (
   conversationID        INTEGER      NOT NULL,
+  roomID                INTEGER,
   room                  VARCHAR(512),
   isExternal            INTEGER      NOT NULL,
   startDate             BIGINT       NOT NULL,
@@ -13,6 +14,7 @@ CREATE TABLE ofConversation (
 CREATE INDEX ofConversation_ext_idx   ON ofConversation (isExternal);
 CREATE INDEX ofConversation_start_idx ON ofConversation (startDate);
 CREATE INDEX ofConversation_last_idx  ON ofConversation (lastActivity);
+CREATE INDEX ofConversation_room_idx  ON ofConversation (roomID);
 
 CREATE TABLE ofConParticipant (
   conversationID       INTEGER       NOT NULL,

--- a/src/database/monitoring_hsqldb.sql
+++ b/src/database/monitoring_hsqldb.sql
@@ -1,8 +1,9 @@
 
-INSERT INTO ofVersion (name, version) VALUES ('monitoring', 8);
+INSERT INTO ofVersion (name, version) VALUES ('monitoring', 9);
 
 CREATE TABLE ofConversation (
   conversationID        BIGINT        NOT NULL,
+  roomID                BIGINT        NULL,
   room                  VARCHAR(1024) NULL,
   isExternal            INT           NOT NULL,
   startDate             BIGINT        NOT NULL,
@@ -13,6 +14,7 @@ CREATE TABLE ofConversation (
 CREATE INDEX ofConversation_ext_idx   ON ofConversation (isExternal);
 CREATE INDEX ofConversation_start_idx ON ofConversation (startDate);
 CREATE INDEX ofConversation_last_idx  ON ofConversation (lastActivity);
+CREATE INDEX ofConversation_room_idx  ON ofConversation (roomID);
 
 CREATE TABLE ofConParticipant (
   conversationID       BIGINT        NOT NULL,

--- a/src/database/monitoring_mysql.sql
+++ b/src/database/monitoring_mysql.sql
@@ -1,8 +1,9 @@
 
-INSERT INTO ofVersion (name, version) VALUES ('monitoring', 8);
+INSERT INTO ofVersion (name, version) VALUES ('monitoring', 9);
 
 CREATE TABLE ofConversation (
   conversationID        BIGINT        NOT NULL,
+  roomID                BIGINT        NULL,
   room                  VARCHAR(255)  NULL,
   isExternal            TINYINT       NOT NULL,
   startDate             BIGINT        NOT NULL,
@@ -11,7 +12,8 @@ CREATE TABLE ofConversation (
   PRIMARY KEY (conversationID),
   INDEX ofConversation_ext_idx (isExternal),
   INDEX ofConversation_start_idx (startDate),
-  INDEX ofConversation_last_idx (lastActivity)
+  INDEX ofConversation_last_idx (lastActivity),
+  INDEX ofConversation_room_idx (roomID)
 );
 
 CREATE TABLE ofConParticipant (

--- a/src/database/monitoring_oracle.sql
+++ b/src/database/monitoring_oracle.sql
@@ -1,8 +1,9 @@
 
-INSERT INTO ofVersion (name, version) VALUES ('monitoring', 8);
+INSERT INTO ofVersion (name, version) VALUES ('monitoring', 9);
 
 CREATE TABLE ofConversation (
   conversationID        INTEGER        NOT NULL,
+  roomID                INTEGER        NULL,
   room                  VARCHAR2(1024) NULL,
   isExternal            NUMBER(2)      NOT NULL,
   startDate             INTEGER        NOT NULL,
@@ -13,6 +14,7 @@ CREATE TABLE ofConversation (
 CREATE INDEX ofConversation_ext_idx   ON ofConversation (isExternal);
 CREATE INDEX ofConversation_start_idx ON ofConversation (startDate);
 CREATE INDEX ofConversation_last_idx  ON ofConversation (lastActivity);
+CREATE INDEX ofConversation_room_idx  ON ofConversation (roomID);
 
 CREATE TABLE ofConParticipant (
   conversationID       INTEGER        NOT NULL,

--- a/src/database/monitoring_postgresql.sql
+++ b/src/database/monitoring_postgresql.sql
@@ -1,8 +1,9 @@
 
-INSERT INTO ofVersion (name, version) VALUES ('monitoring', 8);
+INSERT INTO ofVersion (name, version) VALUES ('monitoring', 9);
 
 CREATE TABLE ofConversation (
   conversationID        INTEGER       NOT NULL,
+  roomID                INTEGER       NULL,
   room                  VARCHAR(1024) NULL,
   isExternal            SMALLINT      NOT NULL,
   startDate             BIGINT        NOT NULL,
@@ -13,6 +14,7 @@ CREATE TABLE ofConversation (
 CREATE INDEX ofConversation_ext_idx   ON ofConversation (isExternal);
 CREATE INDEX ofConversation_start_idx ON ofConversation (startDate);
 CREATE INDEX ofConversation_last_idx  ON ofConversation (lastActivity);
+CREATE INDEX ofConversation_room_idx  ON ofConversation (roomID);
 
 CREATE TABLE ofConParticipant (
   conversationID       INTEGER       NOT NULL,

--- a/src/database/monitoring_sqlserver.sql
+++ b/src/database/monitoring_sqlserver.sql
@@ -1,8 +1,9 @@
 
-INSERT INTO ofVersion (name, version) VALUES ('monitoring', 8);
+INSERT INTO ofVersion (name, version) VALUES ('monitoring', 9);
 
 CREATE TABLE ofConversation (
   conversationID        BIGINT         NOT NULL,
+  roomID                BIGINT         NULL,
   room                  NVARCHAR(1024) NULL,
   isExternal            TINYINT        NOT NULL,
   startDate             BIGINT         NOT NULL,
@@ -13,6 +14,7 @@ CREATE TABLE ofConversation (
 CREATE INDEX ofConversation_ext_idx   ON ofConversation (isExternal);
 CREATE INDEX ofConversation_start_idx ON ofConversation (startDate);
 CREATE INDEX ofConversation_last_idx  ON ofConversation (lastActivity);
+CREATE INDEX ofConversation_room_idx  ON ofConversation (roomID);
 
 CREATE TABLE ofConParticipant (
   conversationID       BIGINT         NOT NULL,

--- a/src/database/upgrade/9/monitoring_db2.sql
+++ b/src/database/upgrade/9/monitoring_db2.sql
@@ -7,7 +7,7 @@ UPDATE ofConversation SET roomID = (
     JOIN ofMucService ON ofMucRoom.serviceID = ofMucService.serviceID
     CROSS JOIN ofProperty
     WHERE ofProperty.name = 'xmpp.domain'
-    AND ofMucRoom.name || '@' || ofMucService.subdomain || ofProperty.propValue = ofConversation.room
+    AND ofMucRoom.name || '@' || ofMucService.subdomain || '.' || ofProperty.propValue = ofConversation.room
 )
 WHERE room IS NOT NULL AND room <> '';
 

--- a/src/database/upgrade/9/monitoring_db2.sql
+++ b/src/database/upgrade/9/monitoring_db2.sql
@@ -1,0 +1,17 @@
+-- Add column that will contain the unique numeric ID of a room.
+ALTER TABLE ofConversation ADD COLUMN roomID INTEGER NULL;
+
+-- Populate the new column with the numeric ID of the room from the ofMucRoom table.
+UPDATE ofConversation SET roomID = (
+    SELECT ofMucRoom.roomID FROM ofMucRoom
+    JOIN ofMucService ON ofMucRoom.serviceID = ofMucService.serviceID
+    CROSS JOIN ofProperty
+    WHERE ofProperty.name = 'xmpp.domain'
+    AND ofMucRoom.name || '@' || ofMucService.subdomain || ofProperty.propValue = ofConversation.room
+)
+WHERE room IS NOT NULL AND room <> '';
+
+CREATE INDEX ofConversation_room_idx ON ofConversation (roomID);
+
+-- Update database version
+UPDATE ofVersion SET version = 9 WHERE name = 'monitoring';

--- a/src/database/upgrade/9/monitoring_hsqldb.sql
+++ b/src/database/upgrade/9/monitoring_hsqldb.sql
@@ -1,0 +1,17 @@
+-- Add column that will contain the unique numeric ID of a room.
+ALTER TABLE ofConversation ADD COLUMN roomID BIGINT NULL;
+
+-- Populate the new column with the numeric ID of the room from the ofMucRoom table.
+UPDATE ofConversation SET roomID = (
+    SELECT ofMucRoom.roomID FROM ofMucRoom
+    JOIN ofMucService ON ofMucRoom.serviceID = ofMucService.serviceID
+    CROSS JOIN ofProperty
+    WHERE ofProperty.name = 'xmpp.domain'
+    AND ofMucRoom.name || '@' || ofMucService.subdomain || ofProperty.propValue = ofConversation.room
+)
+WHERE room IS NOT NULL AND room <> '';
+
+ALTER TABLE ofConversation ADD INDEX ofConversation_room_idx (roomID);
+
+-- Update database version
+UPDATE ofVersion SET version = 9 WHERE name = 'monitoring';

--- a/src/database/upgrade/9/monitoring_hsqldb.sql
+++ b/src/database/upgrade/9/monitoring_hsqldb.sql
@@ -11,7 +11,7 @@ UPDATE ofConversation SET roomID = (
 )
 WHERE room IS NOT NULL AND room <> '';
 
-ALTER TABLE ofConversation ADD INDEX ofConversation_room_idx (roomID);
+CREATE INDEX ofConversation_room_idx ON ofConversation (roomID);
 
 -- Update database version
 UPDATE ofVersion SET version = 9 WHERE name = 'monitoring';

--- a/src/database/upgrade/9/monitoring_hsqldb.sql
+++ b/src/database/upgrade/9/monitoring_hsqldb.sql
@@ -7,7 +7,7 @@ UPDATE ofConversation SET roomID = (
     JOIN ofMucService ON ofMucRoom.serviceID = ofMucService.serviceID
     CROSS JOIN ofProperty
     WHERE ofProperty.name = 'xmpp.domain'
-    AND ofMucRoom.name || '@' || ofMucService.subdomain || ofProperty.propValue = ofConversation.room
+    AND ofMucRoom.name || '@' || ofMucService.subdomain || '.' || ofProperty.propValue = ofConversation.room
 )
 WHERE room IS NOT NULL AND room <> '';
 

--- a/src/database/upgrade/9/monitoring_mysql.sql
+++ b/src/database/upgrade/9/monitoring_mysql.sql
@@ -1,0 +1,17 @@
+-- Add column that will contain the unique numeric ID of a room.
+ALTER TABLE ofConversation ADD COLUMN roomID BIGINT NULL;
+
+-- Populate the new column with the numeric ID of the room from the ofMucRoom table.
+UPDATE ofConversation SET roomID = (
+    SELECT ofMucRoom.roomID FROM ofMucRoom
+    JOIN ofMucService ON ofMucRoom.serviceID = ofMucService.serviceID
+    CROSS JOIN ofProperty
+    WHERE ofProperty.name = 'xmpp.domain'
+    AND CONCAT(ofMucRoom.name, '@', ofMucService.subdomain, '.', ofProperty.propValue) = ofConversation.room
+)
+WHERE room IS NOT NULL AND room <> '';
+
+ALTER TABLE ofConversation ADD INDEX ofConversation_room_idx (roomID);
+
+-- Update database version
+UPDATE ofVersion SET version = 9 WHERE name = 'monitoring';

--- a/src/database/upgrade/9/monitoring_oracle.sql
+++ b/src/database/upgrade/9/monitoring_oracle.sql
@@ -7,7 +7,7 @@ UPDATE ofConversation SET roomID = (
     JOIN ofMucService ON ofMucRoom.serviceID = ofMucService.serviceID
     CROSS JOIN ofProperty
     WHERE ofProperty.name = 'xmpp.domain'
-    AND ofMucRoom.name || '@' || ofMucService.subdomain || ofProperty.propValue = ofConversation.room
+    AND ofMucRoom.name || '@' || ofMucService.subdomain || '.' || ofProperty.propValue = ofConversation.room
 )
 WHERE room IS NOT NULL AND room <> '';
 

--- a/src/database/upgrade/9/monitoring_oracle.sql
+++ b/src/database/upgrade/9/monitoring_oracle.sql
@@ -1,0 +1,17 @@
+-- Add column that will contain the unique numeric ID of a room.
+ALTER TABLE ofConversation ADD roomID INTEGER NULL;
+
+-- Populate the new column with the numeric ID of the room from the ofMucRoom table.
+UPDATE ofConversation SET roomID = (
+    SELECT ofMucRoom.roomID FROM ofMucRoom
+    JOIN ofMucService ON ofMucRoom.serviceID = ofMucService.serviceID
+    CROSS JOIN ofProperty
+    WHERE ofProperty.name = 'xmpp.domain'
+    AND ofMucRoom.name || '@' || ofMucService.subdomain || ofProperty.propValue = ofConversation.room
+)
+WHERE room IS NOT NULL AND room <> '';
+
+CREATE INDEX ofConversation_room_idx ON ofConversation (roomID);
+
+-- Update database version
+UPDATE ofVersion SET version = 9 WHERE name = 'monitoring';

--- a/src/database/upgrade/9/monitoring_postgresql.sql
+++ b/src/database/upgrade/9/monitoring_postgresql.sql
@@ -7,7 +7,7 @@ UPDATE ofConversation SET roomID = (
     JOIN ofMucService ON ofMucRoom.serviceID = ofMucService.serviceID
     CROSS JOIN ofProperty
     WHERE ofProperty.name = 'xmpp.domain'
-    AND ofMucRoom.name || '@' || ofMucService.subdomain || ofProperty.propValue = ofConversation.room
+    AND ofMucRoom.name || '@' || ofMucService.subdomain || '.' || ofProperty.propValue = ofConversation.room
 )
 WHERE room IS NOT NULL AND room <> '';
 

--- a/src/database/upgrade/9/monitoring_postgresql.sql
+++ b/src/database/upgrade/9/monitoring_postgresql.sql
@@ -1,0 +1,17 @@
+-- Add column that will contain the unique numeric ID of a room.
+ALTER TABLE ofConversation ADD COLUMN roomID INTEGER NULL;
+
+-- Populate the new column with the numeric ID of the room from the ofMucRoom table.
+UPDATE ofConversation SET roomID = (
+    SELECT ofMucRoom.roomID FROM ofMucRoom
+    JOIN ofMucService ON ofMucRoom.serviceID = ofMucService.serviceID
+    CROSS JOIN ofProperty
+    WHERE ofProperty.name = 'xmpp.domain'
+    AND ofMucRoom.name || '@' || ofMucService.subdomain || ofProperty.propValue = ofConversation.room
+)
+WHERE room IS NOT NULL AND room <> '';
+
+CREATE INDEX ofConversation_room_idx ON ofConversation (roomID);
+
+-- Update database version
+UPDATE ofVersion SET version = 9 WHERE name = 'monitoring';

--- a/src/database/upgrade/9/monitoring_sqlserver.sql
+++ b/src/database/upgrade/9/monitoring_sqlserver.sql
@@ -1,0 +1,17 @@
+-- Add column that will contain the unique numeric ID of a room.
+ALTER TABLE ofConversation ADD roomID BIGINT NULL;
+
+-- Populate the new column with the numeric ID of the room from the ofMucRoom table.
+UPDATE ofConversation SET roomID = (
+    SELECT ofMucRoom.roomID FROM ofMucRoom
+    JOIN ofMucService ON ofMucRoom.serviceID = ofMucService.serviceID
+    CROSS JOIN ofProperty
+    WHERE ofProperty.name = 'xmpp.domain'
+    AND CONCAT(ofMucRoom.name, '@', ofMucService.subdomain, '.', ofProperty.propValue) = ofConversation.room
+)
+WHERE room IS NOT NULL AND room <> '';
+
+CREATE INDEX ofConversation_room_idx ON ofConversation (roomID);
+
+-- Update database version
+UPDATE ofVersion SET version = 9 WHERE name = 'monitoring';

--- a/src/java/org/jivesoftware/openfire/archive/Conversation.java
+++ b/src/java/org/jivesoftware/openfire/archive/Conversation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008 Jive Software. All rights reserved.
+ * Copyright (C) 2008 Jive Software, 2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,8 @@ import org.slf4j.LoggerFactory;
 import org.xmpp.packet.JID;
 
 import javax.annotation.Nonnull;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
@@ -47,6 +49,7 @@ import java.util.*;
  * @author Matt Tucker
  */
 @XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
 @JiveID(50)
 public class Conversation {
 
@@ -64,8 +67,22 @@ public class Conversation {
     private Date lastActivity;
     @XmlElement
     private int messageCount;
+
+    /**
+     * Unique identifier of the room where the group conversion is taking place. For one-to-one chats there is no room
+     * so this variable will be null.
+     *
+     * This identifier differs from the JID provided in {@link #room}. When a room gets destroyed, and is recreated, it
+     * <em>can</em> be recreated using the same JID. The numeric identifier however, will be unique.
+     */
+    @XmlElement
+    private Long roomID = null;
+
     /**
      * Room where the group conversion is taking place. For one-to-one chats there is no room so this variable will be null.
+     *
+     * This identifier differs from the ID provided in {@link #roomID}. When a room gets destroyed, and is recreated, it
+     * <em>can</em> be recreated using the same JID. The numeric identifier however, will be unique.
      */
     @XmlElement
     @XmlJavaTypeAdapter(XmlSerializer.JidAdapter.class)
@@ -84,7 +101,8 @@ public class Conversation {
         this.lastActivity = startDate;
     }
 
-    public Conversation(JID room, Map<String, UserParticipations> participants, boolean external, Date startDate) {
+    public Conversation(Long roomID, JID room, Map<String, UserParticipations> participants, boolean external, Date startDate) {
+        this.roomID = roomID;
         this.room = room;
         this.participants = participants;
         this.external = external;
@@ -92,13 +110,40 @@ public class Conversation {
         this.lastActivity = startDate;
     }
 
-    public Conversation(JID room, boolean external, Date startDate, Date lastActivity, int messageCount, Map<String, UserParticipations> participants) {
+    public Conversation(Long roomID, JID room, boolean external, Date startDate, Date lastActivity, int messageCount, Map<String, UserParticipations> participants) {
+        this.roomID = roomID;
         this.room = room;
         this.external = external;
         this.startDate = startDate;
         this.lastActivity = lastActivity;
         this.messageCount = messageCount;
         this.participants = participants;
+    }
+
+    /**
+     * Sets the ID of the room where the group conversation is taking place. One-to-one chats should not have a room ID
+     * (or have a value that is <tt>null</tt>).
+     *
+     * This identifier differs from the JID provided in {@link #room}. When a room gets destroyed, and is recreated, it
+     * <em>can</em> be recreated using the same JID. The numeric identifier however, will be unique.
+     *
+     * @param roomID the room ID, or -1 if this is a one-to-one chat.
+     */
+    public void setRoomID(Long roomID) {
+        this.roomID = roomID;
+    }
+
+    /**
+     * Returns the ID of the room where the group conversation is taking place. For one-to-one chats, this method will
+     * return null, as there is no room.
+     *
+     * This identifier differs from the JID provided in {@link #room}. When a room gets destroyed, and is recreated, it
+     * <em>can</em> be recreated using the same JID. The numeric identifier however, will be unique.
+     *
+     * @return the room ID, null if this is a one-to-one chat.
+     */
+    public Long getRoomID() {
+        return roomID;
     }
 
     /**
@@ -125,7 +170,10 @@ public class Conversation {
     /**
      * Returns the JID of the room where the group conversation took place. If the conversation was a one-to-one chat then a <tt>null</tt> value is
      * returned.
-     * 
+     *
+     * This identifier differs from the ID provided in {@link #roomID}. When a room gets destroyed, and is recreated, it
+     * <em>can</em> be recreated using the same JID. The numeric identifier however, will be unique.
+     *
      * @return the JID of room or null if this was a one-to-one chat.
      */
     public JID getRoom() {
@@ -316,12 +364,12 @@ public class Conversation {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Conversation that = (Conversation) o;
-        return conversationID == that.conversationID && external == that.external && messageCount == that.messageCount && Objects.equals(participants, that.participants) && Objects.equals(startDate, that.startDate) && Objects.equals(lastActivity, that.lastActivity) && Objects.equals(room, that.room);
+        return conversationID == that.conversationID && external == that.external && messageCount == that.messageCount && Objects.equals(participants, that.participants) && Objects.equals(startDate, that.startDate) && Objects.equals(lastActivity, that.lastActivity) && Objects.equals(roomID, that.roomID) && Objects.equals(room, that.room);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(conversationID, participants, external, startDate, lastActivity, messageCount, room);
+        return Objects.hash(conversationID, participants, external, startDate, lastActivity, messageCount, roomID, room);
     }
 
     /**

--- a/src/java/org/jivesoftware/openfire/archive/ConversationDAO.java
+++ b/src/java/org/jivesoftware/openfire/archive/ConversationDAO.java
@@ -393,7 +393,7 @@ public class ConversationDAO {
             result.setConversationID(conversationID);
             return result;
         } catch (SQLException sqle) {
-            Log.error("An exception occurred while trying to load conversation {} form database.", conversationID, sqle);
+            Log.error("An exception occurred while trying to load conversation {} from database.", conversationID, sqle);
             return null;
         } finally {
             DbConnectionManager.closeConnection(rs, pstmt, con);

--- a/src/java/org/jivesoftware/openfire/archive/ConversationDAO.java
+++ b/src/java/org/jivesoftware/openfire/archive/ConversationDAO.java
@@ -358,7 +358,7 @@ public class ConversationDAO {
             if (rs.wasNull()) {
                 roomID = null;
             }
-            final JID room = rs.getString(2) == null ? null : new JID(rs.getString(1));
+            final JID room = rs.getString(2) == null ? null : new JID(rs.getString(2));
             final boolean external = rs.getInt(3) == 1;
             final Date startDate = new Date(rs.getLong(4));
             final Date lastActivity = new Date(rs.getLong(5));

--- a/src/java/org/jivesoftware/openfire/archive/ConversationEvent.java
+++ b/src/java/org/jivesoftware/openfire/archive/ConversationEvent.java
@@ -52,6 +52,8 @@ public class ConversationEvent {
     @XmlJavaTypeAdapter(XmlSerializer.JidAdapter.class)
     private JID receiver;
 
+    private Long roomID;
+
     @XmlJavaTypeAdapter(XmlSerializer.JidAdapter.class)
     private JID roomJID;
 
@@ -105,9 +107,10 @@ public class ConversationEvent {
         return event;
     }
 
-    public static ConversationEvent roomDestroyed(JID roomJID, Date date) {
+    public static ConversationEvent roomDestroyed(long roomID, JID roomJID, Date date) {
         ConversationEvent event = new ConversationEvent();
         event.type = Type.roomDestroyed;
+        event.roomID = roomID;
         event.roomJID = roomJID;
         event.date = date;
         return event;
@@ -188,11 +191,11 @@ public class ConversationEvent {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ConversationEvent that = (ConversationEvent) o;
-        return type == that.type && Objects.equals(date, that.date) && Objects.equals(body, that.body) && Objects.equals(stanza, that.stanza) && Objects.equals(sender, that.sender) && Objects.equals(receiver, that.receiver) && Objects.equals(roomJID, that.roomJID) && Objects.equals(user, that.user) && Objects.equals(nickname, that.nickname);
+        return type == that.type && Objects.equals(date, that.date) && Objects.equals(body, that.body) && Objects.equals(stanza, that.stanza) && Objects.equals(sender, that.sender) && Objects.equals(receiver, that.receiver) && Objects.equals(roomID, that.roomID) && Objects.equals(roomJID, that.roomJID) && Objects.equals(user, that.user) && Objects.equals(nickname, that.nickname);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, date, body, stanza, sender, receiver, roomJID, user, nickname);
+        return Objects.hash(type, date, body, stanza, sender, receiver, roomID, roomJID, user, nickname);
     }
 }

--- a/src/java/org/jivesoftware/openfire/archive/ConversationEvent.java
+++ b/src/java/org/jivesoftware/openfire/archive/ConversationEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008 Jive Software. All rights reserved.
+ * Copyright (C) 2008 Jive Software, 2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,12 +76,15 @@ public class ConversationEvent {
         else if (Type.roomDestroyed == type) {
             conversationManager.roomConversationEnded(roomJID, date);
         }
+        else if (Type.roomClearChatHistory == type) {
+            conversationManager.clearChatHistory(roomID);
+        }
         else if (Type.occupantJoined == type) {
             conversationManager.joinedGroupConversation(roomJID, user, nickname, date);
         }
         else if (Type.occupantLeft == type) {
             conversationManager.leftGroupConversation(roomJID, user, date);
-            // If there are no more occupants then consider the group conversation over
+            // If there are no more occupants than consider the group conversation over
             MUCRoom mucRoom = XMPPServer.getInstance().getMultiUserChatManager().getMultiUserChatService(roomJID).getChatRoom(roomJID.getNode());
             if (mucRoom != null &&  mucRoom.getOccupantsCount() == 0) {
                 conversationManager.roomConversationEnded(roomJID, date);
@@ -113,6 +116,14 @@ public class ConversationEvent {
         event.roomID = roomID;
         event.roomJID = roomJID;
         event.date = date;
+        return event;
+    }
+
+    public static ConversationEvent roomClearChatHistory(long roomID, JID roomJID) {
+        ConversationEvent event = new ConversationEvent();
+        event.type = Type.roomClearChatHistory;
+        event.roomID = roomID;
+        event.roomJID = roomJID;
         return event;
     }
 
@@ -164,6 +175,10 @@ public class ConversationEvent {
          * Event triggered when a room was destroyed.
          */
         roomDestroyed,
+        /**
+         * Event triggered when historic data for a room is removed.
+         */
+        roomClearChatHistory,
         /**
          * Event triggered when a new occupant joins a room.
          */

--- a/src/java/org/jivesoftware/openfire/archive/ConversationEvent.java
+++ b/src/java/org/jivesoftware/openfire/archive/ConversationEvent.java
@@ -77,7 +77,7 @@ public class ConversationEvent {
             conversationManager.roomConversationEnded(roomJID, date);
         }
         else if (Type.roomClearChatHistory == type) {
-            conversationManager.clearChatHistory(roomID);
+            conversationManager.clearChatHistory(roomID, roomJID);
         }
         else if (Type.occupantJoined == type) {
             conversationManager.joinedGroupConversation(roomJID, user, nickname, date);

--- a/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
+++ b/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
@@ -928,8 +928,13 @@ public class ConversationManager implements ComponentEventListener{
      * database, and associated data from the Lucene indices.
      *
      * @param roomID the numeric ID for the room
+     * @param roomJID the JID of the room
      */
-    public void clearChatHistory(final long roomID) {
+    public void clearChatHistory(final long roomID, final JID roomJid)
+    {
+        // Ensure that ongoing conversations are marked as 'ended'. New messages should go in a new conversation.
+        roomConversationEnded(roomJid, new Date());
+
         ConversationDAO.deleteRoomMessages(roomID);
         ConversationDAO.deleteRoomParticipants(roomID);
         final Set<Long> deletedConversations = ConversationDAO.deleteRoomConversations(roomID);

--- a/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
+++ b/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008 Jive Software, Ignite Realtime Foundation 2024. All rights reserved.
+ * Copyright (C) 2008 Jive Software, Ignite Realtime Foundation 2024-2025. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -798,7 +798,7 @@ public class ConversationManager implements ComponentEventListener{
     }
 
     /**
-     * Processes an incoming message sent to a room. The message will mapped to a conversation and then queued for storage if archiving is turned on.
+     * Processes an incoming message sent to a room. The message will be mapped to a conversation and then queued for storage if archiving is turned on.
      *
      * @param roomJID
      *            the JID of the room where the group conversation is taking place.

--- a/src/java/org/jivesoftware/openfire/archive/GroupConversationInterceptor.java
+++ b/src/java/org/jivesoftware/openfire/archive/GroupConversationInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008 Jive Software. All rights reserved.
+ * Copyright (C) 2008 Jive Software, 2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import org.xmpp.packet.JID;
 import org.xmpp.packet.Message;
 
+import javax.annotation.Nonnull;
 import java.util.Date;
 
 /**
@@ -60,7 +61,7 @@ public class GroupConversationInterceptor implements MUCEventListener {
     }
 
     @Override
-    public void roomCreated(JID roomJID) {
+    public void roomCreated(final long roomID, @Nonnull final JID roomJID) {
         //Do nothing
     }
 
@@ -70,7 +71,7 @@ public class GroupConversationInterceptor implements MUCEventListener {
     }
 
     @Override
-    public void roomDestroyed(JID roomJID) {
+    public void roomDestroyed(final long roomID, @Nonnull final JID roomJID) {
         // Process this event in the senior cluster member or local JVM when not in a cluster
         if (ClusterManager.isSeniorClusterMember()) {
             conversationManager.roomConversationEnded(roomJID, new Date());
@@ -78,7 +79,7 @@ public class GroupConversationInterceptor implements MUCEventListener {
         else {
             ConversationEventsQueue eventsQueue = conversationManager.getConversationEventsQueue();
             eventsQueue.addGroupChatEvent(conversationManager.getRoomConversationKey(roomJID),
-                    ConversationEvent.roomDestroyed(roomJID, new Date()));
+                    ConversationEvent.roomDestroyed(roomID, roomJID, new Date()));
         }
     }
 

--- a/src/java/org/jivesoftware/openfire/archive/GroupConversationInterceptor.java
+++ b/src/java/org/jivesoftware/openfire/archive/GroupConversationInterceptor.java
@@ -88,7 +88,7 @@ public class GroupConversationInterceptor implements MUCEventListener {
     {
         // Process this event in the senior cluster member or local JVM when not in a cluster
         if (ClusterManager.isSeniorClusterMember()) {
-            conversationManager.clearChatHistory(roomID);
+            conversationManager.clearChatHistory(roomID, roomJID);
         }
         else {
             ConversationEventsQueue eventsQueue = conversationManager.getConversationEventsQueue();

--- a/src/java/org/jivesoftware/openfire/archive/GroupConversationInterceptor.java
+++ b/src/java/org/jivesoftware/openfire/archive/GroupConversationInterceptor.java
@@ -84,6 +84,20 @@ public class GroupConversationInterceptor implements MUCEventListener {
     }
 
     @Override
+    public void roomClearChatHistory(final long roomID, @Nonnull final JID roomJID)
+    {
+        // Process this event in the senior cluster member or local JVM when not in a cluster
+        if (ClusterManager.isSeniorClusterMember()) {
+            conversationManager.clearChatHistory(roomID);
+        }
+        else {
+            ConversationEventsQueue eventsQueue = conversationManager.getConversationEventsQueue();
+            eventsQueue.addGroupChatEvent(conversationManager.getRoomConversationKey(roomJID),
+                ConversationEvent.roomClearChatHistory(roomID, roomJID));
+        }
+    }
+
+    @Override
     public void occupantJoined(JID roomJID, JID user, String nickname) {
         // Process this event in the senior cluster member or local JVM when not in a cluster
         if (ClusterManager.isSeniorClusterMember()) {

--- a/src/test/java/org/jivesoftware/openfire/archive/XmlSerializerTest.java
+++ b/src/test/java/org/jivesoftware/openfire/archive/XmlSerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2021-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ public class XmlSerializerTest {
         userParticipations.addParticipation(participation);
         participations.put("g@d", userParticipations);
         participations.put("a@s/f", userParticipations);
-        final Conversation input = new Conversation(new JID("a@b.c"), true, new Date(1), new Date(2), 8, participations);
+        final Conversation input = new Conversation(-1L, new JID("a@b.c"), true, new Date(1), new Date(2), 8, participations);
 
         // Execute system under test.
         final String xml = XmlSerializer.getInstance().marshall(input);


### PR DESCRIPTION
We can address both #369 and #370 by implementing the handling of the "clear chat history" event from Openfire. Openfire sends a "clear chat history" event in the following scenarios:

- A room is destroyed, and no chat history should be preserved.
- A "clear room history" command is issued during the lifetime of a chat room.

This intends to replace #408 

The approach in this PR differs from the one in 408 in that it does not attempt to introduce a new unique identifier for a room. Instead, an Openfire-provided identifier (`roomID`) is re-used. This intends to:
- better separates concerns: responsibility for generating a unique value now is located in only one piece of functionality (that pre-exists).
- avoids issues when the plugin was not loaded when a room was created
- reduces code complexity

Prior to the changes introduced here, the Monitoring plugin did not distinguish between different 'incarnations' of a room (a room can be deleted, then recreated with the same JID). With the changes in this PR, the plugin now does - but only for data that is recorded 'from now on'. This PR contains a database update script that explicitly relates all preexisting data to the last incarnation of a chat room (if one still exists). This isn't quite right, but it is not 'more wrong' than what was functionally going on prior to these changes.