### PR TITLE
Include commons-io library

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -49,7 +49,7 @@ Monitoring Plugin Changelog
     <li>Requires Openfire 5.0.0</li>
     <li>Note: Chat rooms can, in certain circumstances, be destroyed, and then be recreated using the same name. For data recorded by previous versions of this plugin, the plugin will associate all room history with the latest 'reincarnation' of a room. Starting with this version, new data will be associated to the correct 'incarnation' of the room.</li>
     <li>Updated Chinese (zh_CN) translation</li>
-    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/414'>Issue #415</a>] - Include commons-io library</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/415'>Issue #415</a>] - Include commons-io library</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/409'>Issue #409</a>] - Building Lucene index should not load all messages in memory</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/401'>Issue #401</a>] - Fixes: Update Jersey from 2.35 to 2.45</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/398'>Issue #398</a>] - Fixes: Missing translation for system property</li>

--- a/changelog.html
+++ b/changelog.html
@@ -49,6 +49,7 @@ Monitoring Plugin Changelog
     <li>Requires Openfire 5.0.0</li>
     <li>Note: Chat rooms can, in certain circumstances, be destroyed, and then be recreated using the same name. For data recorded by previous versions of this plugin, the plugin will associate all room history with the latest 'reincarnation' of a room. Starting with this version, new data will be associated to the correct 'incarnation' of the room.</li>
     <li>Updated Chinese (zh_CN) translation</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/414'>Issue #415</a>] - Include commons-io library</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/409'>Issue #409</a>] - Building Lucene index should not load all messages in memory</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/401'>Issue #401</a>] - Fixes: Update Jersey from 2.35 to 2.45</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/398'>Issue #398</a>] - Fixes: Missing translation for system property</li>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,11 @@
             <artifactId>orsonpdf</artifactId>
             <version>1.9</version>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.16.1</version>
+        </dependency>
 
         <!-- For java 9+, see: https://stackoverflow.com/questions/51916221 -->
         <!-- https://mvnrepository.com/artifact/javax.xml.bind/jaxb-api -->


### PR DESCRIPTION
Openfire 5.0.0 will no longer provide the commons-io library. This plugin makes use of that library.

In this commit, the commons-io library is included with the plugin itself.

fixes #415