### PR TITLE
When reconstructing MUC message, use room JID

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -50,6 +50,7 @@ Monitoring Plugin Changelog
     <li>Note: Chat rooms can, in certain circumstances, be destroyed, and then be recreated using the same name. For data recorded by previous versions of this plugin, the plugin will associate all room history with the latest 'reincarnation' of a room. Starting with this version, new data will be associated to the correct 'incarnation' of the room.</li>
     <li>Updated Chinese (zh_CN) translation</li>
     <li>Remove redundant code</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/418'>Issue #418</a>] - Fixes: Incorrect addressing on reconstructed MUC messages</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/415'>Issue #415</a>] - Include commons-io library</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/413'>Issue #413</a>] - Fixes GetSupportedFieldVariables throws java.lang.UnsupportedOperationException</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/409'>Issue #409</a>] - Building Lucene index should not load all messages in memory</li>


### PR DESCRIPTION
When the monitoring plugin didn't store the entire stanza, it will attempt to reconstruct a stanza from the metadata that was stored.

When a message is a MUC message, the room JID rather than the real JIDs of the sender should be used in the reconstructed message.

fixes #418 