### PR TITLE
Require Openfire 5.0.0-beta (rather than alpha)

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
     <description>Monitors conversations and statistics of the server.</description>
     <author>Ignite Realtime</author>
     <version>${project.version}</version>
-    <date>2025-01-19</date>
+    <date>2025-06-11</date>
     <minServerVersion>5.0.0</minServerVersion>
     <databaseKey>monitoring</databaseKey>
     <databaseVersion>9</databaseVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>5.0.0-alpha</version>
+        <version>5.0.0-beta</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>monitoring</artifactId>


### PR DESCRIPTION
5.0.0-beta is close to what the actual release will be, and has some interesting improvements over the alpha. This plugin should build against 5.0.0-beta or later, not 5.0.0-alpha (as that misses some important changes).

This change depends on Openfire 5.0.0-beta being released, which is the subject of https://github.com/igniterealtime/Openfire/pull/2813/

After 5.0.0-beta makes it into a Maven repository, this PR should successfully build.