### PR TITLE
fixes #365: Fixes error when using 'before' or 'after' with unrecognized value in personal archives

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -44,6 +44,11 @@
 Monitoring Plugin Changelog
 </h1>
 
+<p><b>2.7.1</b> -- (to be determined)</p>
+<ul>
+    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/365'>Issue #365</a>] - Fixes error when using 'before' or 'after' with unrecognized value in personal archives</li>
+</ul>
+
 <p><b>2.7.0</b> -- June 12, 2025</p>
 <ul>
     <li>Requires Openfire 5.0.0</li>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
     <description>Monitors conversations and statistics of the server.</description>
     <author>Ignite Realtime</author>
     <version>${project.version}</version>
-    <date>2025-06-12</date>
+    <date>2025-06-21</date>
     <minServerVersion>5.0.0</minServerVersion>
     <databaseKey>monitoring</databaseKey>
     <databaseVersion>9</databaseVersion>

--- a/src/java/com/reucon/openfire/plugin/archive/impl/MucMamPersistenceManager.java
+++ b/src/java/com/reucon/openfire/plugin/archive/impl/MucMamPersistenceManager.java
@@ -218,10 +218,10 @@ public class MucMamPersistenceManager implements PersistenceManager {
         try {
             result = parseIdentifier(value, room, useStableID);
         } catch ( IllegalArgumentException e ) {
-            // When a 'before' or 'after' element is present, but is not present in the archive, XEP-0313 specifies that a item-not-found error must be returned.
+            // When a 'before' or 'after' element is present, but is not present in the archive, XEP-0313 specifies that an item-not-found error must be returned.
             throw new NotFoundException( "The reference '"+value+"' used in the '"+fieldName+"' RSM element is not recognized.");
         }
-        // When a 'before' or 'after' element is present, but is not present in the archive, XEP-0313 specifies that a item-not-found error must be returned.
+        // When a 'before' or 'after' element is present, but is not present in the archive, XEP-0313 specifies that an item-not-found error must be returned.
         if ( result == null || getArchivedMessage( result, room ) == null ) {
             throw new NotFoundException( "The reference '"+value+"' used in the '"+fieldName+"' RSM element is not recognized.");
         }


### PR DESCRIPTION
This duplicates the fix for #79, which was applied only to MUC archives.