### PR TITLE
Prevent database storage issue when using statistics with a key that's longer than 20 characters

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -47,6 +47,7 @@ Monitoring Plugin Changelog
 <p><b>2.8.0</b> -- (to be determined)</p>
 <ul>
     <li>Requires Openfire 5.1.0</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/436'>Issue #436</a>] - Prevent database storage issue when using statistics with a key that's longer than 20 characters</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/435'>Issue #435</a>] - Stop using deprecated statistics. Note: this will cause the historical graphs (which go back 7 days) to be reset</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/365'>Issue #365</a>] - Fixes error when using 'before' or 'after' with unrecognized value in personal archives</li>
 </ul>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
     <description>Monitors conversations and statistics of the server.</description>
     <author>Ignite Realtime</author>
     <version>${project.version}</version>
-    <date>2025-11-10</date>
+    <date>2025-11-17</date>
     <minServerVersion>5.1.0</minServerVersion>
     <databaseKey>monitoring</databaseKey>
     <databaseVersion>9</databaseVersion>

--- a/src/java/org/jivesoftware/openfire/reporting/stats/RrdUtil.java
+++ b/src/java/org/jivesoftware/openfire/reporting/stats/RrdUtil.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2025 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire.reporting.stats;
+
+import javax.annotation.Nonnull;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * Utility methods for working with Round Robin Database instances (and/or Java's implementation thereof).
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ */
+public class RrdUtil
+{
+    // 36^20 as a BigInteger for modulo operation
+    private static final BigInteger MOD_36_20 = BigInteger.valueOf(36).pow(20);
+
+    /**
+     * A RRD Data Source name cannot be longer than 20 characters. This method returns the provided value if it's not
+     * longer than that, or a 20-character hash of the provided value when it is.
+     *
+     * @param rrdDataSourceName The name for which to return a valid variant
+     * @return A value not longer than 20 characters.
+     */
+    public static String ensureValidRrdDataSourceName(@Nonnull final String rrdDataSourceName)
+    {
+        if (rrdDataSourceName.length() > 20) {
+            return generateHash(rrdDataSourceName);
+        } else {
+            return rrdDataSourceName;
+        }
+    }
+
+    /**
+     * Generates a 20-character base-36 hash of the given input string using SHA-256.
+     *
+     * This method hashes the input string with SHA-256, then compresses the full 256-bit hash into exactly 20 base-36
+     * characters by taking the modulo 36^20. Leading zeros are added if necessary to ensure the length is exactly 20.
+     *
+     * Characteristics of the output:
+     * <ul>
+     * <li>Exactly 20 characters long.</li>
+     * <li>Uses the full entropy of SHA-256.</li>
+     * <li>Deterministic: same input always produces the same hash.</li>
+     * <li>Extremely low probability of collisions due to SHA-256 uniformity.</li>
+     * </ul>
+     * </p>
+     *
+     * @param input the input string to hash; must not be null
+     * @return a 20-character base-36 encoded string representing the hash of the input
+     * @throws RuntimeException if the SHA-256 algorithm is not available
+     */
+    public static String generateHash(@Nonnull final String input)
+    {
+        try {
+            // Hash input with SHA-256
+            final MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            final byte[] hashBytes = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+
+            // Convert full hash to positive BigInteger
+            final BigInteger hashInt = new BigInteger(1, hashBytes);
+
+            // Compress to fit 20 base-36 chars
+            final BigInteger compressed = hashInt.mod(MOD_36_20);
+
+            // Convert to base-36 string
+            final String base36 = compressed.toString(36);
+
+            // Pad with leading zeros to ensure exactly 20 characters
+            return String.format("%20s", base36).replace(' ', '0');
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-256 algorithm not available", e);
+        }
+    }
+}

--- a/src/java/org/jivesoftware/openfire/reporting/stats/StatDefinition.java
+++ b/src/java/org/jivesoftware/openfire/reporting/stats/StatDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008 Jive Software. All rights reserved.
+ * Copyright (C) 2008 Jive Software, 2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 package org.jivesoftware.openfire.reporting.stats;
 
 import org.jivesoftware.openfire.stats.Statistic;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A class used by the StatsEngine to track all relevant meta information and data
@@ -26,6 +28,8 @@ import org.jivesoftware.openfire.stats.Statistic;
  */
 abstract class StatDefinition {
 
+    private static final Logger Log = LoggerFactory.getLogger(StatDefinition.class);
+
     private String dbPath;
     private String datasourceName;
     private Statistic stat;
@@ -34,8 +38,11 @@ abstract class StatDefinition {
 
     StatDefinition(String dbPath, String datasourceName, Statistic stat) {
         this.dbPath = dbPath;
-        this.datasourceName = datasourceName;
+        this.datasourceName = RrdUtil.ensureValidRrdDataSourceName(datasourceName);
         this.stat = stat;
+        if (!this.datasourceName.equals(datasourceName)) {
+            Log.debug("The provided data source name for path '{}' was: '{}'. This value cannot be used by the RRD implementation. This value will be used instead: '{}'.", dbPath, datasourceName, this.datasourceName);
+        }
     }
 
     public String getDbPath() {

--- a/src/test/java/org/jivesoftware/openfire/reporting/stats/RrdUtilTest.java
+++ b/src/test/java/org/jivesoftware/openfire/reporting/stats/RrdUtilTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2025 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire.reporting.stats;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for {@link RrdUtil#ensureValidRrdDataSourceName(String)}.
+ *
+ * These tests validate that the method correctly returns or hashes input names
+ * according to the 20-character limit defined for RRD Data Source names.
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ */
+public class RrdUtilTest
+{
+    /**
+     * Verifies that a short name (less than 20 characters) is returned unchanged.
+     */
+    @Test
+    public void shortNameReturnsUnchanged()
+    {
+        // Setup test fixture.
+        String input = "ShortName123";
+
+        // Execute System under Test.
+        String result = RrdUtil.ensureValidRrdDataSourceName(input);
+
+        // Verify Result.
+        assertEquals("Names ≤ 20 characters should be returned unchanged", input, result);
+    }
+
+    /**
+     * Verifies that a name exactly 20 characters long is returned unchanged.
+     */
+    @Test
+    public void exactLengthNameReturnsUnchanged()
+    {
+        // Setup test fixture.
+        String input = "ABCDEFGHIJKLMNOPQRST"; // exactly 20 chars
+
+        // Execute System under Test.
+        String result = RrdUtil.ensureValidRrdDataSourceName(input);
+
+        // Verify Result.
+        assertEquals("Names with exactly 20 characters should be returned unchanged", input, result);
+    }
+
+    /**
+     * Verifies that a name longer than 20 characters is hashed into a 20-character result.
+     */
+    @Test
+    public void longNameGetsHashed()
+    {
+        // Setup test fixture.
+        String input = "ThisIsALongDataSourceNameExceeding20Chars";
+
+        // Execute System under Test.
+        String result = RrdUtil.ensureValidRrdDataSourceName(input);
+
+        // Verify Result.
+        assertNotNull("Result should not be null", result);
+        assertEquals("Hashed names must be exactly 20 characters long", 20, result.length());
+    }
+
+    /**
+     * Verifies that an empty string input is returned unchanged.
+     */
+    @Test
+    public void emptyNameReturnsUnchanged()
+    {
+        // Setup test fixture.
+        String input = "";
+
+        // Execute System under Test.
+        String result = RrdUtil.ensureValidRrdDataSourceName(input);
+
+        // Verify Result.
+        assertEquals("Empty names should be returned unchanged", input, result);
+    }
+
+    /**
+     * Verifies that passing null throws a NullPointerException due to @Nonnull annotation.
+     */
+    @Test(expected = NullPointerException.class)
+    public void nullInputThrowsException() {
+        // Setup test fixture.
+        String input = null;
+
+        // Execute System under Test.
+        RrdUtil.ensureValidRrdDataSourceName(input);
+
+        // Verify Result. (Handled by expected exception)
+    }
+
+    /**
+     * Verifies that the hashing is deterministic - same input yields same hash.
+     */
+    @Test
+    public void hashIsDeterministic()
+    {
+        // Setup test fixture.
+        String input = "SomeVeryLongDataSourceNameThatNeedsHashing";
+
+        // Execute System under Test.
+        String result1 = RrdUtil.ensureValidRrdDataSourceName(input);
+        String result2 = RrdUtil.ensureValidRrdDataSourceName(input);
+
+        // Verify Result.
+        assertEquals("Hash output should be consistent for the same input", result1, result2);
+    }
+}


### PR DESCRIPTION
RRD's implementation in Java requires a data source name that's no longer than 20 characters. The key under which Openfire's Statistic definition instances are stored in the StatisticsManager are used as a RRD data source name. Thus, if that key is longer than 20 characters, an error is logged (and data points are not stored in the database).

To prevent this issue, this commit introduces a new method that ensures that the value used is not longer than 20 characters. It will use the original value if it matches that criterium, or use a 20-character hash (which is designed to be uniformly distributed) if it's longer.

As a note of caution: the hashing function was provided by AI. It _seems_ sensible to me, but it has not exhaustively tested (other than through the basic unit test that is added as part of this commit).

fixes #436