### PR TITLE
fixes #461: ORA-01400 when archiving conversations with bare JIDs on Oracle

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -47,6 +47,7 @@ Monitoring Plugin Changelog
 <p><b>2.8.0</b> -- (to be determined)</p>
 <ul>
     <li>Requires Openfire 5.1.0</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/461'>Issue #461</a>] - ORA-01400 crash when archiving a conversation that involves a bare JID (no resource) on Oracle</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/441'>Issue #441</a>] - Enable message archiving by default</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/439'>Issue #439</a>] - Prevent leaking real JIDs through message archive when querying MUC private messages</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-monitoring-plugin/issues/436'>Issue #436</a>] - Prevent database storage issue when using statistics with a key that's longer than 20 characters</li>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
     <description>Monitors conversations and statistics of the server.</description>
     <author>Ignite Realtime</author>
     <version>${project.version}</version>
-    <date>2025-12-09</date>
+    <date>2026-04-06</date>
     <minServerVersion>5.1.0</minServerVersion>
     <databaseKey>monitoring</databaseKey>
     <databaseVersion>10</databaseVersion>

--- a/src/java/org/jivesoftware/openfire/archive/ConversationDAO.java
+++ b/src/java/org/jivesoftware/openfire/archive/ConversationDAO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2025 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2021-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -374,7 +374,7 @@ public class ConversationDAO {
                 // Rebuild full JID of participant
                 String baredJID = rs.getString(1);
                 String resource = rs.getString(2);
-                JID fullJID = new JID("".equals(resource) ? baredJID : baredJID + "/" + resource);
+                JID fullJID = new JID(hasStoredResource(resource) ? baredJID + "/" + resource : baredJID);
                 // Rebuild joined and left time
                 ConversationParticipation participation = new ConversationParticipation(new Date(rs.getLong(4)), rs.getString(3));
                 if (rs.getLong(5) > 0) {
@@ -432,7 +432,7 @@ public class ConversationDAO {
                     pstmt.setLong(1, conversation.getConversationID());
                     pstmt.setLong(2, participation.getJoined().getTime());
                     pstmt.setString(3, user.toBareJID());
-                    pstmt.setString(4, user.getResource() == null ? "" : user.getResource());
+                    pstmt.setString(4, toStoredResource(user));
                     pstmt.setString(5, participation.getNickname());
                     pstmt.executeUpdate();
                 }
@@ -466,12 +466,48 @@ public class ConversationDAO {
             pstmt.setLong(1, conversationID);
             pstmt.setLong(2, joined);
             pstmt.setString(3, participant.toBareJID());
-            pstmt.setString(4, participant.getResource() == null ? "" : participant.getResource());
+            pstmt.setString(4, toStoredResource(participant));
             pstmt.setString(5, nickname);
             pstmt.executeUpdate();
             pstmt.close();
         } finally {
             DbConnectionManager.closeConnection(con);
         }
+    }
+
+    /**
+     * Converts a JID resource into the value that is stored in the {@code jidResource} column of {@code ofConParticipant}.
+     *
+     * Oracle treats empty strings as {@code NULL}, which would violate the {@code NOT NULL} constraint on
+     * {@code jidResource}. When the database is Oracle and the JID has no resource (i.e. it is a bare JID),
+     * a single-space sentinel value is used instead of an empty string. On all other databases the historic
+     * empty-string value is preserved.
+     *
+     * @param jid the JID whose resource part is to be stored.
+     * @return the value to store in the {@code jidResource} column; never {@code null}.
+     * @see <a href="https://github.com/igniterealtime/openfire-monitoring-plugin/issues/461">ORA-01400 crash when archiving a conversation that involves a bare JID (no resource) on Oracle</a>
+     */
+    static String toStoredResource(final JID jid)
+    {
+        if (jid.getResource() != null) {
+            return jid.getResource();
+        }
+        return DbConnectionManager.getDatabaseType() == DbConnectionManager.DatabaseType.oracle ? " " : "";
+    }
+
+    /**
+     * Determines whether a value read from the {@code jidResource} column of {@code ofConParticipant} represents
+     * a real XMPP resource.
+     *
+     * Both an empty string (used by non-Oracle databases for bare JIDs) and the single-space sentinel (used by
+     * Oracle, because Oracle treats empty strings as {@code NULL}) are considered "no resource" values and cause
+     * this method to return {@code false}.
+     *
+     * @param storedResource the raw value read from the database column.
+     * @return {@code true} if the value represents an actual JID resource; {@code false} if it is absent or a sentinel.
+     */
+    static boolean hasStoredResource(final String storedResource)
+    {
+        return storedResource != null && !storedResource.trim().isEmpty();
     }
 }

--- a/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
+++ b/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008 Jive Software, Ignite Realtime Foundation 2024-2025. All rights reserved.
+ * Copyright (C) 2008 Jive Software, Ignite Realtime Foundation 2024-2026. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1432,7 +1432,7 @@ public class ConversationManager implements ComponentEventListener{
                     pstmt.setLong(1, work.left.getTime());
                     pstmt.setLong(2, work.conversationID);
                     pstmt.setString(3, work.user.toBareJID());
-                    pstmt.setString(4, work.user.getResource() == null ? " " : work.user.getResource());
+                    pstmt.setString(4, ConversationDAO.toStoredResource(work.user));
                     pstmt.setLong(5, work.joined.getTime());
                     if ( DbConnectionManager.isBatchUpdatesSupported() )
                     {


### PR DESCRIPTION
Oracle treats empty strings as NULL. The ofConParticipant.jidResource column is defined NOT NULL, so inserting an empty string for participants whose JID has no resource (i.e. bare JIDs) raised ORA-01400 on Oracle, preventing the conversation from being persisted at all.

Fix by writing a single-space sentinel value to jidResource when the database is Oracle and the JID has no resource part.

All other databases retain the historic empty-string value. Deserialization is updated to treat both empty string and the single-space sentinel as "no resource", so JIDs are reconstructed correctly regardless of which database was used to write the row.