### PR TITLE
fixes #472: MAM private-message query duplicated results after a rejoin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <!-- Same version Openfire itself bundles; used here for an in-memory schema in tests, not at runtime. -->
+            <groupId>org.hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
+            <version>2.7.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.igniterealtime.smack</groupId>
             <artifactId>smack-integration-test</artifactId>
             <version>4.5.0-beta9</version>

--- a/src/java/com/reucon/openfire/plugin/archive/impl/PaginatedMessageDatabaseQuery.java
+++ b/src/java/com/reucon/openfire/plugin/archive/impl/PaginatedMessageDatabaseQuery.java
@@ -88,42 +88,7 @@ public class PaginatedMessageDatabaseQuery extends AbstractPaginatedMamQuery
             final String query = buildQueryForMessages(after, before, maxResults, isPagingBackwards);
             pstmt = connection.prepareStatement( query );
 
-            int pos = 0;
-
-            // For the date filters.
-            pstmt.setLong( ++pos, dateToMillis( startDate ) );
-            pstmt.setLong( ++pos, dateToMillis( endDate ) );
-
-            // For the one-on-one where-clause
-            if (with == null) {
-                pstmt.setString( ++pos, archiveOwner.toBareJID() );
-                pstmt.setString( ++pos, archiveOwner.toBareJID() );
-            } else if (with.getResource() == null) {
-                pstmt.setString( ++pos, archiveOwner.toBareJID() );
-                pstmt.setString( ++pos, with.toBareJID() );
-                pstmt.setString( ++pos, with.toBareJID() );
-                pstmt.setString( ++pos, archiveOwner.toBareJID() );
-            } else {
-                pstmt.setString( ++pos, archiveOwner.toBareJID() );
-                pstmt.setString( ++pos, with.toBareJID() );
-                pstmt.setString( ++pos, with.getResource() );
-                pstmt.setString( ++pos, with.toBareJID() );
-                pstmt.setString( ++pos, with.getResource() );
-                pstmt.setString( ++pos, archiveOwner.toBareJID() );
-            }
-
-            // For the private-messages where-clause
-            pstmt.setString(++pos, archiveOwner.toBareJID());
-            pstmt.setString(++pos, archiveOwner.toBareJID());
-            if (with != null) {
-                pstmt.setString( ++pos, with.toBareJID() );
-                if (with.getResource() != null) {
-                    pstmt.setString( ++pos, archiveOwner.toBareJID() );
-                    pstmt.setString( ++pos, with.getResource() );
-                    pstmt.setString( ++pos, archiveOwner.toBareJID() );
-                    pstmt.setString( ++pos, with.getResource() );
-                }
-            }
+            int pos = bindCommonParameters(pstmt);
 
             if ( after != null ) {
                 pstmt.setLong( ++pos, after );
@@ -172,42 +137,7 @@ public class PaginatedMessageDatabaseQuery extends AbstractPaginatedMamQuery
             connection = DbConnectionManager.getConnection();
             pstmt = connection.prepareStatement( buildQueryForTotalCount() );
 
-            int pos = 0;
-
-            // For the date filters.
-            pstmt.setLong( ++pos, dateToMillis( startDate ) );
-            pstmt.setLong( ++pos, dateToMillis( endDate ) );
-
-            // For the one-on-one where-clause
-            if (with == null) {
-                pstmt.setString( ++pos, archiveOwner.toBareJID() );
-                pstmt.setString( ++pos, archiveOwner.toBareJID() );
-            } else if (with.getResource() == null) {
-                pstmt.setString( ++pos, archiveOwner.toBareJID() );
-                pstmt.setString( ++pos, with.toBareJID() );
-                pstmt.setString( ++pos, with.toBareJID() );
-                pstmt.setString( ++pos, archiveOwner.toBareJID() );
-            } else {
-                pstmt.setString( ++pos, archiveOwner.toBareJID() );
-                pstmt.setString( ++pos, with.toBareJID() );
-                pstmt.setString( ++pos, with.getResource() );
-                pstmt.setString( ++pos, with.toBareJID() );
-                pstmt.setString( ++pos, with.getResource() );
-                pstmt.setString( ++pos, archiveOwner.toBareJID() );
-            }
-
-            // For the private-messages where-clause
-            pstmt.setString(++pos, archiveOwner.toBareJID());
-            pstmt.setString(++pos, archiveOwner.toBareJID());
-            if (with != null) {
-                pstmt.setString( ++pos, with.toBareJID() );
-                if (with.getResource() != null) {
-                    pstmt.setString( ++pos, archiveOwner.toBareJID() );
-                    pstmt.setString( ++pos, with.getResource() );
-                    pstmt.setString( ++pos, archiveOwner.toBareJID() );
-                    pstmt.setString( ++pos, with.getResource() );
-                }
-            }
+            bindCommonParameters(pstmt);
 
             Log.trace( "Constructed query: {}", pstmt );
             rs = pstmt.executeQuery();
@@ -222,7 +152,59 @@ public class PaginatedMessageDatabaseQuery extends AbstractPaginatedMamQuery
         return totalCount;
     }
 
-    private String buildQueryForMessages( @Nullable final Long after, @Nullable final Long before, final int maxResults, final boolean isPagingBackwards )
+    /**
+     * Binds the parameters shared by the date filter, the one-on-one where-clause, and the private-messages
+     * where-clause. {@link #getPage(Long, Long, int, boolean)} has two further parameters (the after/before
+     * navigation cursor) that this does not bind; the returned index is the last one this method used, so that
+     * caller can continue from there.
+     *
+     * @param pstmt the prepared statement to bind parameters on. Its SQL must have been built by
+     *              {@link #buildQueryForMessages(Long, Long, int, boolean)} or {@link #buildQueryForTotalCount()}.
+     * @return the index of the last parameter that this method bound.
+     */
+    int bindCommonParameters(final PreparedStatement pstmt) throws SQLException
+    {
+        int pos = 0;
+
+        // For the date filters.
+        pstmt.setLong( ++pos, dateToMillis( startDate ) );
+        pstmt.setLong( ++pos, dateToMillis( endDate ) );
+
+        // For the one-on-one where-clause
+        if (with == null) {
+            pstmt.setString( ++pos, archiveOwner.toBareJID() );
+            pstmt.setString( ++pos, archiveOwner.toBareJID() );
+        } else if (with.getResource() == null) {
+            pstmt.setString( ++pos, archiveOwner.toBareJID() );
+            pstmt.setString( ++pos, with.toBareJID() );
+            pstmt.setString( ++pos, with.toBareJID() );
+            pstmt.setString( ++pos, archiveOwner.toBareJID() );
+        } else {
+            pstmt.setString( ++pos, archiveOwner.toBareJID() );
+            pstmt.setString( ++pos, with.toBareJID() );
+            pstmt.setString( ++pos, with.getResource() );
+            pstmt.setString( ++pos, with.toBareJID() );
+            pstmt.setString( ++pos, with.getResource() );
+            pstmt.setString( ++pos, archiveOwner.toBareJID() );
+        }
+
+        // For the private-messages where-clause
+        pstmt.setString(++pos, archiveOwner.toBareJID());
+        pstmt.setString(++pos, archiveOwner.toBareJID());
+        if (with != null) {
+            pstmt.setString( ++pos, with.toBareJID() );
+            if (with.getResource() != null) {
+                pstmt.setString( ++pos, archiveOwner.toBareJID() );
+                pstmt.setString( ++pos, with.getResource() );
+                pstmt.setString( ++pos, archiveOwner.toBareJID() );
+                pstmt.setString( ++pos, with.getResource() );
+            }
+        }
+
+        return pos;
+    }
+
+    String buildQueryForMessages( @Nullable final Long after, @Nullable final Long before, final int maxResults, final boolean isPagingBackwards )
     {
         /* Database table 'ofMessageArchive' content examples:
          *
@@ -252,18 +234,6 @@ public class PaginatedMessageDatabaseQuery extends AbstractPaginatedMamQuery
             FROM ofMessageArchive a
             LEFT JOIN ofConversation c ON a.conversationID = c.conversationID
             """;
-
-        // An additional join is required to be able to answer queries that attempt to filter for private messages for a particular participant.
-        if (with != null && with.getResource() != null) {
-            sql += """
-                LEFT JOIN ofConParticipant senderP
-                       ON a.conversationID = senderP.conversationID
-                      AND a.fromJID = senderP.bareJID
-                LEFT JOIN ofConParticipant targetP
-                       ON a.conversationID = targetP.conversationID
-                      AND a.isPMforJID = targetP.bareJID
-                """;
-        }
 
         // Ignoring 'messageID IS NULL' as they are legacy messages.
         sql += """
@@ -305,7 +275,7 @@ public class PaginatedMessageDatabaseQuery extends AbstractPaginatedMamQuery
         return sql;
     }
 
-    private String buildQueryForTotalCount()
+    String buildQueryForTotalCount()
     {
         String sql = """
             SELECT COUNT(DISTINCT a.messageID)
@@ -315,18 +285,6 @@ public class PaginatedMessageDatabaseQuery extends AbstractPaginatedMamQuery
             FROM ofMessageArchive a
             LEFT JOIN ofConversation c ON a.conversationID = c.conversationID
             """;
-
-        // An additional join is required to be able to answer queries that attempt to filter for private messages for a particular participant.
-        if (with != null && with.getResource() != null) {
-            sql += """
-                LEFT JOIN ofConParticipant senderP
-                       ON a.conversationID = senderP.conversationID
-                      AND a.fromJID = senderP.bareJID
-                LEFT JOIN ofConParticipant targetP
-                       ON a.conversationID = targetP.conversationID
-                      AND a.isPMforJID = targetP.bareJID
-                """;
-        }
 
         // Ignoring 'messageID IS NULL' as they are legacy messages.
         sql += """
@@ -429,10 +387,26 @@ public class PaginatedMessageDatabaseQuery extends AbstractPaginatedMamQuery
             if (with.getResource() != null) {
                 // When the 'with' filter value is a full JID, it is an occupant JID that further filters for a specific
                 // nickname. This nickname is either the sender or recipient of the messages that are of interest.
+                //
+                // A participant can rejoin a room while a conversation is ongoing, adding a new row to
+                // ofConParticipant for the same (conversationID, bareJID) pair each time. Joining that table
+                // directly (as this used to) matches every such row, multiplying each archived message once per
+                // extra rejoin. EXISTS only tests for a match without adding rows to the result, so a participant
+                // with multiple rows for this conversation still contributes each underlying message exactly once.
                 sql += """
                       AND (
-                             (a.fromJID = ? AND targetP.nickname = ?)
-                          OR (a.isPMforJID = ? AND senderP.nickname = ?)
+                             (a.fromJID = ? AND EXISTS (
+                                 SELECT 1 FROM ofConParticipant
+                                  WHERE conversationID = a.conversationID
+                                    AND bareJID = a.isPMforJID
+                                    AND nickname = ?
+                             ))
+                          OR (a.isPMforJID = ? AND EXISTS (
+                                 SELECT 1 FROM ofConParticipant
+                                  WHERE conversationID = a.conversationID
+                                    AND bareJID = a.fromJID
+                                    AND nickname = ?
+                             ))
                           )
                 """;
             }

--- a/src/test/java/com/reucon/openfire/plugin/archive/impl/PaginatedMessageDatabaseQueryTest.java
+++ b/src/test/java/com/reucon/openfire/plugin/archive/impl/PaginatedMessageDatabaseQueryTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2026 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.reucon.openfire.plugin.archive.impl;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.xmpp.packet.JID;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Verifies that {@link PaginatedMessageDatabaseQuery} returns each archived private ("whisper") message exactly
+ * once when a query filters by occupant nickname, even when the occupant has rejoined the room (and so has more
+ * than one row in {@code ofConParticipant} for the same conversation). See
+ * <a href="https://github.com/igniterealtime/openfire-monitoring-plugin/issues/472">issue 472</a>.
+ *
+ * These tests build the SQL and bind its parameters using the same, package-visible methods that
+ * {@link PaginatedMessageDatabaseQuery#getPage} and {@link PaginatedMessageDatabaseQuery#getTotalCount} use in
+ * production ({@link PaginatedMessageDatabaseQuery#buildQueryForMessages},
+ * {@link PaginatedMessageDatabaseQuery#buildQueryForTotalCount},
+ * {@link PaginatedMessageDatabaseQuery#bindCommonParameters}). They run that SQL directly against a fresh
+ * in-memory HSQLDB schema built here, rather than through {@code DbConnectionManager}, so that they don't need a
+ * running Openfire server.
+ */
+public class PaginatedMessageDatabaseQueryTest
+{
+    private static final JID OWNER = new JID("owner@example.com");
+    // A full occupant JID: the resource ("bob") is the nickname the private message filter matches on.
+    private static final JID WITH_NICKNAME = new JID("room@conference.example.com/bob");
+    private static final long CONVERSATION_ID = 1L;
+    private static final long MESSAGE_ID = 42L;
+    private static final long SENT_DATE = 1_000L;
+
+    private Connection connection;
+
+    @Before
+    public void setUp() throws SQLException
+    {
+        // A fresh, uniquely-named in-memory database per test avoids any state leaking between tests.
+        connection = DriverManager.getConnection(
+            "jdbc:hsqldb:mem:" + getClass().getSimpleName() + System.nanoTime(), "SA", "");
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("""
+                CREATE TABLE ofConversation (
+                  conversationID BIGINT NOT NULL,
+                  roomID         BIGINT NULL,
+                  PRIMARY KEY (conversationID)
+                )
+                """);
+            stmt.execute("""
+                CREATE TABLE ofConParticipant (
+                  conversationID BIGINT       NOT NULL,
+                  bareJID        VARCHAR(255) NOT NULL,
+                  nickname       VARCHAR(255) NULL
+                )
+                """);
+            stmt.execute("""
+                CREATE TABLE ofMessageArchive (
+                  messageID       BIGINT        NULL,
+                  conversationID  BIGINT        NOT NULL,
+                  fromJID         VARCHAR(1024) NOT NULL,
+                  fromJIDResource VARCHAR(255)  NULL,
+                  toJID           VARCHAR(1024) NOT NULL,
+                  toJIDResource   VARCHAR(255)  NULL,
+                  sentDate        BIGINT        NOT NULL,
+                  stanza          LONGVARCHAR   NULL,
+                  body            LONGVARCHAR   NULL,
+                  isPMforJID      VARCHAR(1024) NULL
+                )
+                """);
+            // A room conversation, so buildWhereClauseForPrivateMessages's "c.roomID IS NOT NULL" holds.
+            stmt.execute("INSERT INTO ofConversation (conversationID, roomID) VALUES (" + CONVERSATION_ID + ", 100)");
+            // The occupant ("bob") rejoined the room once during the conversation: two participant rows for the
+            // same (conversationID, bareJID), which is exactly what a join on those two columns alone can't
+            // distinguish, and exactly what issue 472 reports.
+            stmt.execute("INSERT INTO ofConParticipant (conversationID, bareJID, nickname) VALUES ("
+                + CONVERSATION_ID + ", 'bob@example.com', 'bob')");
+            stmt.execute("INSERT INTO ofConParticipant (conversationID, bareJID, nickname) VALUES ("
+                + CONVERSATION_ID + ", 'bob@example.com', 'bob')");
+            // One private message, from bob (the occupant with two participant rows) to the archive owner.
+            stmt.execute("INSERT INTO ofMessageArchive "
+                + "(messageID, conversationID, fromJID, toJID, sentDate, body, isPMforJID) VALUES ("
+                + MESSAGE_ID + ", " + CONVERSATION_ID + ", 'bob@example.com', "
+                + "'room@conference.example.com', " + SENT_DATE + ", 'hello', 'owner@example.com')");
+        }
+    }
+
+    @After
+    public void tearDown() throws SQLException
+    {
+        connection.close();
+    }
+
+    @Test
+    public void testPrivateMessageWithRejoinedOccupantIsReturnedOnceInPage() throws SQLException
+    {
+        final PaginatedMessageDatabaseQuery query =
+            new PaginatedMessageDatabaseQuery(new Date(0), new Date(SENT_DATE + 1), OWNER, WITH_NICKNAME);
+
+        final String sql = query.buildQueryForMessages(null, null, 10, false);
+        try (PreparedStatement pstmt = connection.prepareStatement(sql)) {
+            query.bindCommonParameters(pstmt);
+            try (ResultSet rs = pstmt.executeQuery()) {
+                int rowCount = 0;
+                while (rs.next()) {
+                    rowCount++;
+                    assertEquals(MESSAGE_ID, rs.getLong("messageID"));
+                }
+                assertEquals("A message from an occupant with two participant rows (one rejoin) "
+                    + "should be returned once, not once per participant row", 1, rowCount);
+            }
+        }
+    }
+
+    @Test
+    public void testPrivateMessageWithRejoinedOccupantCountsAsOne() throws SQLException
+    {
+        final PaginatedMessageDatabaseQuery query =
+            new PaginatedMessageDatabaseQuery(new Date(0), new Date(SENT_DATE + 1), OWNER, WITH_NICKNAME);
+
+        final String sql = query.buildQueryForTotalCount();
+        try (PreparedStatement pstmt = connection.prepareStatement(sql)) {
+            query.bindCommonParameters(pstmt);
+            try (ResultSet rs = pstmt.executeQuery()) {
+                assertTrue(rs.next());
+                assertEquals(1, rs.getInt(1));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #472

## Root cause

`PaginatedMessageDatabaseQuery` (the personal-archive MAM query) filters a private ("whisper") message search by occupant nickname by joining `ofMessageArchive` to `ofConParticipant` twice — once aliased `senderP`, once `targetP` — purely so `buildWhereClauseForPrivateMessages` could compare `senderP.nickname`/`targetP.nickname` against the requested nickname. Neither join alias is ever selected.

An occupant who rejoins the room during an ongoing conversation gets an additional row in `ofConParticipant` for the same `(conversationID, bareJID)` pair rather than reusing the existing one. Joining on those two columns then matches every one of that participant's rows, so each archived message involving them is duplicated once per extra row — i.e. once per rejoin.

## Fix

Replace both `LEFT JOIN ofConParticipant` blocks with `EXISTS` correlated subqueries that ask the identical nickname question without adding rows to the result:

```sql
AND (
       (a.fromJID = ? AND EXISTS (
           SELECT 1 FROM ofConParticipant
            WHERE conversationID = a.conversationID
              AND bareJID = a.isPMforJID
              AND nickname = ?
       ))
    OR (a.isPMforJID = ? AND EXISTS (
           SELECT 1 FROM ofConParticipant
            WHERE conversationID = a.conversationID
              AND bareJID = a.fromJID
              AND nickname = ?
       ))
    )
```

This applies to both `buildQueryForMessages` (paging) and `buildQueryForTotalCount`, which share this WHERE-clause builder, so the count and the page stay consistent. The number and order of bound `?` placeholders is unchanged, so no parameter-binding code needed to change to match.

I checked whether the simpler fix of adding `SELECT DISTINCT`/`COUNT(DISTINCT ...)` on top of the existing joins would do instead, but `ofMessageArchive.stanza` and `.body` are `CLOB` on Oracle (see `monitoring_oracle.sql`), and Oracle rejects `DISTINCT`/`ORDER BY`/`GROUP BY` over a `CLOB` column (`ORA-00932`), so that approach would break Oracle deployments. Eliminating the joins avoids the problem entirely rather than working around it.

## Refactor (no behaviour change)

`getPage()` and `getTotalCount()` bound their query parameters via two near-identical, hand-duplicated blocks. Pulled the shared logic out into one package-private `bindCommonParameters(PreparedStatement)` method, used by both. This isn't required for the fix itself, but it lets the new test call the actual production binding code (via a package-visible entry point) instead of a hand-copied reproduction of the binding order that could silently drift out of sync with production later.

## Testing

Added `PaginatedMessageDatabaseQueryTest`, a JUnit test that builds an in-memory HSQLDB schema (from the plugin's own `monitoring_hsqldb.sql` table definitions) with one occupant who has two `ofConParticipant` rows for the same conversation (simulating a rejoin) and one private message from that occupant. It asserts:
- the paged query returns that message exactly once, not once per participant row
- the total-count query reports `1`, not `2`

I verified this test fails for the right reason against the pre-fix code: reintroducing the two `LEFT JOIN ofConParticipant` blocks (keeping the refactor, since the test depends on it to compile) makes `testPrivateMessageWithRejoinedOccupantIsReturnedOnceInPage` fail with `expected:<1> but was:<2>` — exactly the join-based fan-out this PR fixes, doubled by the fixture's one rejoin. Restoring the fix returns both tests to passing.

`mvn test -Dtest=PaginatedMessageDatabaseQueryTest` passes locally (`Tests run: 2, Failures: 0, Errors: 0`).
